### PR TITLE
refactor: string field into bytes32 to save gas

### DIFF
--- a/contracts/AgentRegistry.sol
+++ b/contracts/AgentRegistry.sol
@@ -17,7 +17,7 @@ contract AgentRegistry is GenericRegistry {
         // IPFS hashes of the agent
         Multihash[] agentHashes;
         // Description of the agent
-        string description;
+        bytes32 description;
         // Set of component dependencies
         uint256[] dependencies;
         // Agent activity
@@ -63,7 +63,7 @@ contract AgentRegistry is GenericRegistry {
     /// @param description Description of the agent.
     /// @param dependencies Set of component dependencies (component Ids).
     function _setAgentInfo(uint256 agentId, address developer, Multihash memory agentHash,
-        string memory description, uint256[] memory dependencies)
+        bytes32 description, uint256[] memory dependencies)
         private
     {
         Agent storage agent = mapTokenIdAgent[agentId];
@@ -83,7 +83,7 @@ contract AgentRegistry is GenericRegistry {
     /// @param description Description of the agent.
     /// @param dependencies Set of component dependencies in a sorted ascending order (component Ids).
     /// @return agentId The id of a minted agent.
-    function create(address agentOwner, address developer, Multihash memory agentHash, string memory description,
+    function create(address agentOwner, address developer, Multihash memory agentHash, bytes32 description,
         uint256[] memory dependencies)
         external
         checkHash(agentHash)
@@ -106,7 +106,7 @@ contract AgentRegistry is GenericRegistry {
         }
 
         // Checks for non-empty description and component dependency
-        if (bytes(description).length == 0) {
+        if (description == 0) {
             revert ZeroValue();
         }
 //        require(dependencies.length > 0, "Agent must have at least one component dependency");
@@ -168,7 +168,7 @@ contract AgentRegistry is GenericRegistry {
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
     function getInfo(uint256 agentId) external view
-        returns (address agentOwner, address developer, Multihash memory agentHash, string memory description,
+        returns (address agentOwner, address developer, Multihash memory agentHash, bytes32 description,
             uint256 numDependencies, uint256[] memory dependencies)
     {
         if (agentId > 0 && agentId < (totalSupply + 1)) {

--- a/contracts/ComponentRegistry.sol
+++ b/contracts/ComponentRegistry.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.15;
 
 import "./GenericRegistry.sol";
-import "./interfaces/IRegistry.sol";
 
 /// @title Component Registry - Smart contract for registering components
 /// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
@@ -19,8 +18,7 @@ contract ComponentRegistry is GenericRegistry {
         // TODO Or (initial hash <=> set of hashes) map. Here we could store only the initial hash
         Multihash[] componentHashes;
         // Description of the component
-        // TODO string in struct is very expensive. One solution is bytes32
-        string description;
+        bytes32 description;
         // Set of component dependencies
         // TODO Think of smaller values than uint256 to save storage
         uint256[] dependencies;
@@ -66,7 +64,7 @@ contract ComponentRegistry is GenericRegistry {
     /// @param description Description of the component.
     /// @param dependencies Set of component dependencies.
     function _setComponentInfo(uint256 componentId, address developer, Multihash memory componentHash,
-        string memory description, uint256[] memory dependencies)
+        bytes32 description, uint256[] memory dependencies)
         private
     {
         Component storage component = mapTokenIdComponent[componentId];
@@ -88,7 +86,7 @@ contract ComponentRegistry is GenericRegistry {
     /// @param description Description of the component.
     /// @param dependencies Set of component dependencies in a sorted ascending order (component Ids).
     /// @return componentId The id of a minted component.
-    function create(address componentOwner, address developer, Multihash memory componentHash, string memory description,
+    function create(address componentOwner, address developer, Multihash memory componentHash, bytes32 description,
         uint256[] memory dependencies)
         external
         checkHash(componentHash)
@@ -111,7 +109,7 @@ contract ComponentRegistry is GenericRegistry {
         }
 
         // Checks for non-empty description and component dependency
-        if (bytes(description).length == 0) {
+        if (description == 0) {
             revert ZeroValue();
         }
         
@@ -174,7 +172,7 @@ contract ComponentRegistry is GenericRegistry {
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
     function getInfo(uint256 componentId) external view
-        returns (address componentOwner, address developer, Multihash memory componentHash, string memory description,
+        returns (address componentOwner, address developer, Multihash memory componentHash, bytes32 description,
             uint256 numDependencies, uint256[] memory dependencies)
     {
         // Check for the component existence

--- a/contracts/RegistriesManager.sol
+++ b/contracts/RegistriesManager.sol
@@ -31,7 +31,7 @@ contract RegistriesManager is GenericManager {
         address agentOwner,
         address developer,
         IRegistry.Multihash memory agentHash,
-        string memory description,
+        bytes32 description,
         uint256[] memory dependencies
     ) external returns (uint256)
     {
@@ -60,7 +60,7 @@ contract RegistriesManager is GenericManager {
         address componentOwner,
         address developer,
         IRegistry.Multihash memory componentHash,
-        string memory description,
+        bytes32 description,
         uint256[] memory dependencies
     ) external returns (uint256)
     {

--- a/contracts/interfaces/IRegistry.sol
+++ b/contracts/interfaces/IRegistry.sol
@@ -24,7 +24,7 @@ interface IRegistry {
         address owner,
         address developer,
         Multihash memory mHash,
-        string memory description,
+        bytes32 description,
         uint256[] memory dependencies
     ) external returns (uint256);
 
@@ -51,7 +51,7 @@ interface IRegistry {
         address owner,
         address developer,
         Multihash memory mHash,
-        string memory description,
+        bytes32 description,
         uint256 numDependencies,
         uint256[] memory dependencies
     );

--- a/test/AgentRegistry.js
+++ b/test/AgentRegistry.js
@@ -7,7 +7,7 @@ describe("AgentRegistry", function () {
     let componentRegistry;
     let agentRegistry;
     let signers;
-    const description = "agent description";
+    const description = ethers.utils.formatBytes32String("agent description");
     const agentHash = {hash: "0x" + "0".repeat(64), hashFunction: "0x12", size: "0x20"};
     const agentHash1 = {hash: "0x" + "1".repeat(64), hashFunction: "0x12", size: "0x20"};
     const agentHash2 = {hash: "0x" + "2".repeat(64), hashFunction: "0x12", size: "0x20"};
@@ -97,7 +97,7 @@ describe("AgentRegistry", function () {
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
             await expect(
-                agentRegistry.connect(mechManager).create(user.address, user.address, agentHash, "",
+                agentRegistry.connect(mechManager).create(user.address, user.address, agentHash, "0x" + "0".repeat(64),
                     dependencies)
             ).to.be.revertedWith("ZeroValue");
         });
@@ -166,14 +166,15 @@ describe("AgentRegistry", function () {
                 agentHash, description, dependencies);
             await componentRegistry.connect(mechManager).create(user.address, user.address,
                 agentHash1, description, dependencies);
+            const description2 = ethers.utils.id("component description2");
             await agentRegistry.connect(mechManager).create(user.address, user.address,
-                agentHash2, description + "2", lastDependencies);
+                agentHash2, description2, lastDependencies);
 
             let agentInfo = await agentRegistry.getInfo(tokenId);
             expect(agentInfo.agentOwner).to.equal(user.address);
             expect(agentInfo.developer).to.equal(user.address);
             expect(agentInfo.agentHash.hash).to.equal(agentHash2.hash);
-            expect(agentInfo.description).to.equal(description + "2");
+            expect(agentInfo.description).to.equal(description2);
             expect(agentInfo.numDependencies).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
                 expect(agentInfo.dependencies[i]).to.equal(lastDependencies[i]);

--- a/test/ComponentRegistry.js
+++ b/test/ComponentRegistry.js
@@ -6,7 +6,7 @@ const { ethers } = require("hardhat");
 describe("ComponentRegistry", function () {
     let componentRegistry;
     let signers;
-    const description = "component description";
+    const description = ethers.utils.formatBytes32String("component description");
     const componentHash = {hash: "0x" + "0".repeat(64), hashFunction: "0x12", size: "0x20"};
     const componentHash1 = {hash: "0x" + "1".repeat(64), hashFunction: "0x12", size: "0x20"};
     const componentHash2 = {hash: "0x" + "2".repeat(64), hashFunction: "0x12", size: "0x20"};
@@ -92,8 +92,8 @@ describe("ComponentRegistry", function () {
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash, "",
-                    dependencies)
+                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash,
+                    "0x" + "0".repeat(64), dependencies)
             ).to.be.revertedWith("ZeroValue");
         });
 
@@ -170,14 +170,15 @@ describe("ComponentRegistry", function () {
                 componentHash, description, dependencies);
             await componentRegistry.connect(mechManager).create(user.address, user.address,
                 componentHash1, description, dependencies);
+            const description2 = ethers.utils.id("component description2");
             await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash2, description + "2", lastDependencies);
+                componentHash2, description2, lastDependencies);
 
             let compInfo = await componentRegistry.getInfo(tokenId);
             expect(compInfo.componentOwner).to.equal(user.address);
             expect(compInfo.developer).to.equal(user.address);
             expect(compInfo.componentHash.hash).to.equal(componentHash2.hash);
-            expect(compInfo.description).to.equal(description + "2");
+            expect(compInfo.description).to.equal(description2);
             expect(compInfo.numDependencies).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
                 expect(compInfo.dependencies[i]).to.equal(lastDependencies[i]);

--- a/test/RegistriesManager.js
+++ b/test/RegistriesManager.js
@@ -8,7 +8,7 @@ describe("RegistriesManager", function () {
     let agentRegistry;
     let registriesManager;
     let signers;
-    const description = "description";
+    const description = ethers.utils.formatBytes32String("unit description");
     const componentHashes = [{hash: "0x" + "0".repeat(64), hashFunction: "0x12", size: "0x20"},
         {hash: "0x" + "1".repeat(64), hashFunction: "0x12", size: "0x20"}];
     const agentHashes = [{hash: "0x" + "5".repeat(64), hashFunction: "0x12", size: "0x20"},

--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -11,6 +11,7 @@ describe("ServiceRegistry", function () {
     let signers;
     const name = "service name";
     const description = "service description";
+    const unitDescription = ethers.utils.formatBytes32String("unit description");
     const configHash = {hash: "0x" + "5".repeat(64), hashFunction: "0x12", size: "0x20"};
     const configHash1 = {hash: "0x" + "6".repeat(64), hashFunction: "0x12", size: "0x20"};
     const regBond = 1000;
@@ -161,7 +162,7 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
                 serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1, 1],
@@ -174,8 +175,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
                 serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1, 0],
@@ -188,8 +189,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
                 serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
@@ -203,8 +204,8 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
             const minThreshold = Math.floor(maxThreshold * 2 / 3 + 1);
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
                 serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
@@ -225,8 +226,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             const service = await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash,
                 agentIds, agentParams, maxThreshold);
@@ -239,8 +240,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -280,8 +281,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -300,8 +301,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -318,8 +319,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -368,8 +369,8 @@ describe("ServiceRegistry", function () {
             const agentInstance = signers[7].address;
 
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -385,8 +386,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description,
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription,
                 []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
@@ -405,8 +406,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -424,8 +425,8 @@ describe("ServiceRegistry", function () {
             const agentInstances = [signers[7].address, signers[8].address, signers[9].address, signers[10].address];
             const regAgentIds = [agentId, agentId, agentId, agentId];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -442,8 +443,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -461,8 +462,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = [signers[7].address, signers[8].address, signers[9].address];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -485,8 +486,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstances = [signers[7].address, signers[8].address];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -526,8 +527,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -543,8 +544,8 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
 
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -559,8 +560,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -580,8 +581,8 @@ describe("ServiceRegistry", function () {
 
             // Create agents and a service
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -611,8 +612,8 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
@@ -635,13 +636,13 @@ describe("ServiceRegistry", function () {
 
             // Create components
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, [1]);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, [1]);
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1, 2]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, [1]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, unitDescription, [1, 2]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -699,13 +700,13 @@ describe("ServiceRegistry", function () {
 
             // Create components
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, [1]);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, [1]);
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1, 2]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, [1]);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, unitDescription, [1, 2]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -752,8 +753,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[2];
             const owner = signers[3].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
 
             // Initially owner does not have any services
             expect(await serviceRegistry.exists(serviceId)).to.equal(false);
@@ -790,9 +791,9 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[2];
             const owner = signers[3].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash2, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
                 agentParams, maxThreshold);
@@ -853,7 +854,7 @@ describe("ServiceRegistry", function () {
             const regAgentIds = [agentId, agentId];
             const maxThreshold = 2;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
@@ -890,7 +891,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -913,7 +914,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -940,8 +941,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, componentHash1, unitDescription, []);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating the service
@@ -966,7 +967,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -1023,7 +1024,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -1060,7 +1061,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -1083,7 +1084,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -1106,8 +1107,8 @@ describe("ServiceRegistry", function () {
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, unitDescription, []);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
@@ -1140,7 +1141,7 @@ describe("ServiceRegistry", function () {
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -1198,7 +1199,7 @@ describe("ServiceRegistry", function () {
 
             // Create an agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, []);
+            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, unitDescription, []);
 
             // Create services and activate the agent instance registration
             let state = await serviceRegistry.getServiceState(serviceId);


### PR DESCRIPTION
- Description field from string to bytes32 to make sure we spend no more than 32 symbols in the description;
- Service struct is not yet modified, it will require its own break down;
- All the tests are updated.