### PR TITLE
refactor: terminated-unbonded state is now pre-registration

### DIFF
--- a/contracts/ServiceRegistry.sol
+++ b/contracts/ServiceRegistry.sol
@@ -42,8 +42,7 @@ contract ServiceRegistry is GenericRegistry {
         ActiveRegistration,
         FinishedRegistration,
         Deployed,
-        TerminatedBonded,
-        TerminatedUnbonded
+        TerminatedBonded
     }
 
     // TODO After all maps are extracted from the struct, this can be treated as memory
@@ -626,15 +625,14 @@ contract ServiceRegistry is GenericRegistry {
 
         Service memory service = mapServices[serviceId];
         // Check if the service is already terminated
-        if (service.state == ServiceState.PreRegistration || service.state == ServiceState.TerminatedBonded ||
-            service.state == ServiceState.TerminatedUnbonded) {
+        if (service.state == ServiceState.PreRegistration || service.state == ServiceState.TerminatedBonded) {
             revert WrongServiceState(uint256(service.state), serviceId);
         }
         // Define the state of the service depending on the number of bonded agent instances
         if (service.numAgentInstances > 0) {
             service.state = ServiceState.TerminatedBonded;
         } else {
-            service.state = ServiceState.TerminatedUnbonded;
+            service.state = ServiceState.PreRegistration;
         }
         mapServices[serviceId] = service;
 
@@ -690,7 +688,7 @@ contract ServiceRegistry is GenericRegistry {
         // Subtract number of unbonded agent instances
         service.numAgentInstances -= uint32(numAgentsUnbond);
         if (service.numAgentInstances == 0) {
-            service.state = ServiceState.TerminatedUnbonded;
+            service.state = ServiceState.PreRegistration;
         }
 
         // Calculate registration refund and free all agent instances

--- a/docs/FSM.md
+++ b/docs/FSM.md
@@ -6,7 +6,6 @@ Let's first describe the list of possible states:
 - Service is finished-registration; -> All the agent instances slots are registered
 - Service is deployed; -> Service is deployed and operates via created multisig contract
 - Service is terminated-bonded; -> Some agents are bonded with stake
-- Service is terminated-unbonded; -> All agents have left the service and recovered their stake
 
 In v1 the service has a static set of agent instances following activation of the registration.
 
@@ -30,11 +29,11 @@ would throw an error.
 
 ### terminate()
 - **Current state:** active-registration or finished-registration or deployed
-- **Next state:** terminated-bonded or terminated-unbonded
+- **Next state:** terminated-bonded or pre-registration
 
 ### unbond()
 - **Current state:** expired-registration or terminated-bonded
-- **Next state:** expired-registration or terminated-unbonded
+- **Next state:** expired-registration or pre-registration
    
 ### registerAgents()
 - **Current state:** Service is active-registration
@@ -85,7 +84,7 @@ Functions to call from this state:
     - Condition: At least one agent instance is registered
 
 
-3. **Service is terminated-unbonded**
+3. **Service is pre-registration**
     - Function call for this state: **terminate()**
     - Condition: No single agent instance is registered
 
@@ -111,14 +110,8 @@ Functions to call from this state:
 
 
 List of next possible states:
-1. **Service is terminated-unbonded**
+1. **Service is pre-registration**
     - Function call for this state: **unbond()**
     - Condition: No single agent instance is registered after the function call
 
-### Service is terminated-unbonded
-Condition for this state: Service termination block has passed and all agent instances have left the service and recovered
-their stake or have never registered for the service.
-
-Functions to call from this state:
-- None
 

--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -585,7 +585,7 @@ describe("ServiceRegistry", function () {
 
             // The service state must be terminated-unbonded
             const state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(6);
+            expect(state).to.equal(1);
         });
     });
 
@@ -937,7 +937,7 @@ describe("ServiceRegistry", function () {
             await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
             // The service state must be terminated-unbonded
             const state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(6);
+            expect(state).to.equal(1);
         });
 
         it("Unbond when the service registration is terminated", async function () {
@@ -991,7 +991,7 @@ describe("ServiceRegistry", function () {
             expect(result.events[0].event).to.equal("Refund");
             expect(result.events[1].event).to.equal("OperatorUnbond");
             const state = await serviceRegistry.getServiceState(serviceId);
-            expect(state).to.equal(6);
+            expect(state).to.equal(1);
 
             // Operator's balance after unbonding must be zero
             const newBalanceOperator = Number(await serviceRegistry.getOperatorBalance(operator, serviceId));


### PR DESCRIPTION
- Terminated-unbonded state is now Pre-registration;
- Updated FSM;
- Updated tests.