### PR TITLE
refactor: getting rid of service names, unit developers

### DIFF
--- a/contracts/RegistriesManager.sol
+++ b/contracts/RegistriesManager.sol
@@ -22,16 +22,14 @@ contract RegistriesManager is GenericManager {
 
     /// @dev Creates agent.
     /// @param agentOwner Owner of the agent.
-    /// @param developer Developer of the agent.
-    /// @param agentHash IPFS hash of the agent.
     /// @param description Description of the agent.
+    /// @param agentHash IPFS hash of the agent.
     /// @param dependencies Set of component dependencies in a sorted ascending order.
     /// @return The id of a created agent.
     function createAgent(
         address agentOwner,
-        address developer,
-        bytes32 agentHash,
         bytes32 description,
+        bytes32 agentHash,
         uint32[] memory dependencies
     ) external returns (uint256)
     {
@@ -39,7 +37,7 @@ contract RegistriesManager is GenericManager {
         if (paused) {
             revert Paused();
         }
-        return IRegistry(agentRegistry).create(agentOwner, developer, agentHash, description, dependencies);
+        return IRegistry(agentRegistry).create(agentOwner, description, agentHash, dependencies);
     }
 
     /// @dev Updates the agent hash.
@@ -51,16 +49,14 @@ contract RegistriesManager is GenericManager {
 
     /// @dev Creates component.
     /// @param componentOwner Owner of the component.
-    /// @param developer Developer of the component.
-    /// @param componentHash IPFS hash of the component.
     /// @param description Description of the component.
+    /// @param componentHash IPFS hash of the component.
     /// @param dependencies Set of component dependencies in a sorted ascending order.
     /// @return The id of a created component.
     function createComponent(
         address componentOwner,
-        address developer,
-        bytes32 componentHash,
         bytes32 description,
+        bytes32 componentHash,
         uint32[] memory dependencies
     ) external returns (uint256)
     {
@@ -68,7 +64,7 @@ contract RegistriesManager is GenericManager {
         if (paused) {
             revert Paused();
         }
-        return IRegistry(componentRegistry).create(componentOwner, developer, componentHash, description, dependencies);
+        return IRegistry(componentRegistry).create(componentOwner, description, componentHash, dependencies);
     }
 
     /// @dev Updates the component hash.

--- a/contracts/ServiceManager.sol
+++ b/contracts/ServiceManager.sol
@@ -54,7 +54,6 @@ contract ServiceManager is GenericManager {
 
     /// @dev Creates a new service.
     /// @param serviceOwner Individual that creates and controls a service.
-    /// @param name Name of the service.
     /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids.
@@ -62,8 +61,7 @@ contract ServiceManager is GenericManager {
     /// @param threshold Threshold for a multisig composed by agents.
     function serviceCreate(
         address serviceOwner,
-        string memory name,
-        string memory description,
+        bytes32 description,
         bytes32 configHash,
         uint256[] memory agentIds,
         IService.AgentParams[] memory agentParams,
@@ -74,12 +72,11 @@ contract ServiceManager is GenericManager {
         if (paused) {
             revert Paused();
         }
-        return IService(serviceRegistry).create(serviceOwner, name, description, configHash, agentIds, agentParams,
+        return IService(serviceRegistry).create(serviceOwner, description, configHash, agentIds, agentParams,
             threshold);
     }
 
     /// @dev Updates a service in a CRUD way.
-    /// @param name Name of the service.
     /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids.
@@ -87,8 +84,7 @@ contract ServiceManager is GenericManager {
     /// @param threshold Threshold for a multisig composed by agents.
     /// @param serviceId Service Id to be updated.
     function serviceUpdate(
-        string memory name,
-        string memory description,
+        bytes32 description,
         bytes32 configHash,
         uint256[] memory agentIds,
         IService.AgentParams[] memory agentParams,
@@ -96,7 +92,7 @@ contract ServiceManager is GenericManager {
         uint256 serviceId
     ) external
     {
-        IService(serviceRegistry).update(msg.sender, name, description, configHash, agentIds, agentParams,
+        IService(serviceRegistry).update(msg.sender, description, configHash, agentIds, agentParams,
             threshold, serviceId);
     }
 

--- a/contracts/interfaces/IRegistry.sol
+++ b/contracts/interfaces/IRegistry.sol
@@ -5,24 +5,22 @@ pragma solidity ^0.8.14;
 interface IRegistry {
     /// @dev Creates component / agent.
     /// @param owner Owner of the component / agent.
-    /// @param developer Developer of the component / agent.
-    /// @param mHash IPFS hash of the component / agent.
     /// @param description Description of the component / agent.
+    /// @param unitHash IPFS hash of the component / agent.
     /// @param dependencies Set of component dependencies in a sorted ascending order.
     /// @return The id of a minted component / agent.
     function create(
         address owner,
-        address developer,
-        bytes32 mHash,
         bytes32 description,
+        bytes32 unitHash,
         uint32[] memory dependencies
     ) external returns (uint256);
 
     /// @dev Updates the component / agent hash.
     /// @param owner Owner of the component / agent.
     /// @param unitId Unit Id.
-    /// @param mHash New IPFS hash of the component / agent.
-    function updateHash(address owner, uint256 unitId, bytes32 mHash) external;
+    /// @param unitHash New IPFS hash of the component / agent.
+    function updateHash(address owner, uint256 unitId, bytes32 unitHash) external;
 
     /// @dev Check for the component / agent existence.
     /// @param unitId Unit Id.
@@ -32,15 +30,13 @@ interface IRegistry {
     /// @dev Gets the component / agent info.
     /// @param unitId Unit Id.
     /// @return owner Owner of the component / agent.
-    /// @return developer The component developer.
-    /// @return mHash The primary component / agent IPFS hash.
+    /// @return unitHash The primary component / agent IPFS hash.
     /// @return description The component / agent description.
     /// @return numDependencies The number of components in the dependency list.
     /// @return dependencies The list of component dependencies.
     function getInfo(uint256 unitId) external view returns (
         address owner,
-        address developer,
-        bytes32 mHash,
+        bytes32 unitHash,
         bytes32 description,
         uint256 numDependencies,
         uint32[] memory dependencies
@@ -68,8 +64,8 @@ interface IRegistry {
     /// @dev Gets updated component / agent hashes.
     /// @param unitId Unit Id.
     /// @return numHashes Number of hashes.
-    /// @return mHashes The list of component / agent hashes.
-    function getUpdatedHashes(uint256 unitId) external view returns (uint256 numHashes, bytes32[] memory mHashes);
+    /// @return unitHashes The list of component / agent hashes.
+    function getUpdatedHashes(uint256 unitId) external view returns (uint256 numHashes, bytes32[] memory unitHashes);
 
     /// @dev Gets the total supply of components / agents.
     /// @return Total supply.

--- a/contracts/interfaces/IService.sol
+++ b/contracts/interfaces/IService.sol
@@ -12,7 +12,6 @@ interface IService{
 
     /// @dev Creates a new service.
     /// @param owner Individual that creates and controls a service.
-    /// @param name Name of the service.
     /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids in a sorted ascending order.
@@ -21,8 +20,7 @@ interface IService{
     /// @return serviceId Created service Id.
     function create(
         address owner,
-        string memory name,
-        string memory description,
+        bytes32 description,
         bytes32 configHash,
         uint256[] memory agentIds,
         AgentParams[] memory agentParams,
@@ -31,7 +29,6 @@ interface IService{
 
     /// @dev Updates a service in a CRUD way.
     /// @param owner Individual that creates and controls a service.
-    /// @param name Name of the service.
     /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids in a sorted ascending order.
@@ -41,8 +38,7 @@ interface IService{
     /// @return success True, if function executed successfully.
     function update(
         address owner,
-        string memory name,
-        string memory description,
+        bytes32 description,
         bytes32 configHash,
         uint256[] memory agentIds,
         AgentParams[] memory agentParams,

--- a/test/ComponentRegistry.js
+++ b/test/ComponentRegistry.js
@@ -49,25 +49,15 @@ describe("ComponentRegistry", function () {
         it("Should fail when creating a component without a mechManager", async function () {
             const user = signers[2];
             await expect(
-                componentRegistry.create(user.address, user.address, componentHash, description, dependencies)
+                componentRegistry.create(user.address, description, componentHash, dependencies)
             ).to.be.revertedWith("ManagerOnly");
         });
 
-        it("Should fail when creating a component with a zero address of owner and / or developer", async function () {
+        it("Should fail when creating a component with a zero owner address", async function () {
             const mechManager = signers[1];
-            const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
             await expect(
-                componentRegistry.connect(mechManager).create(AddressZero, user.address, componentHash, description,
-                    dependencies)
-            ).to.be.revertedWith("ZeroAddress");
-            await expect(
-                componentRegistry.connect(mechManager).create(user.address, AddressZero, componentHash, description,
-                    dependencies)
-            ).to.be.revertedWith("ZeroAddress");
-            await expect(
-                componentRegistry.connect(mechManager).create(AddressZero, AddressZero, componentHash, description,
-                    dependencies)
+                componentRegistry.connect(mechManager).create(AddressZero, description, componentHash, dependencies)
             ).to.be.revertedWith("ZeroAddress");
         });
 
@@ -76,8 +66,8 @@ describe("ComponentRegistry", function () {
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash,
-                    "0x" + "0".repeat(64), dependencies)
+                componentRegistry.connect(mechManager).create(user.address, "0x" + "0".repeat(64), componentHash,
+                    dependencies)
             ).to.be.revertedWith("ZeroValue");
         });
 
@@ -85,11 +75,9 @@ describe("ComponentRegistry", function () {
             const mechManager = signers[1];
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address, componentHash,
-                description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash, dependencies);
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash,
-                    description, dependencies)
+                componentRegistry.connect(mechManager).create(user.address, description, componentHash, dependencies)
             ).to.be.revertedWith("HashExists");
         });
 
@@ -98,12 +86,10 @@ describe("ComponentRegistry", function () {
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash,
-                    description, [0])
+                componentRegistry.connect(mechManager).create(user.address, description, componentHash, [0])
             ).to.be.revertedWith("ComponentNotFound");
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash,
-                    description, [1])
+                componentRegistry.connect(mechManager).create(user.address, description, componentHash, [1])
             ).to.be.revertedWith("ComponentNotFound");
         });
 
@@ -111,15 +97,13 @@ describe("ComponentRegistry", function () {
             const mechManager = signers[1];
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address, componentHash, description, []);
-            await componentRegistry.connect(mechManager).create(user.address, user.address, componentHash1, description, [1]);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash, []);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash1, [1]);
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash2,
-                    description, [1, 1, 1])
+                componentRegistry.connect(mechManager).create(user.address, description, componentHash2, [1, 1, 1])
             ).to.be.revertedWith("ComponentNotFound");
             await expect(
-                componentRegistry.connect(mechManager).create(user.address, user.address, componentHash2,
-                    description, [2, 1, 2, 1, 1, 1, 2])
+                componentRegistry.connect(mechManager).create(user.address, description, componentHash2, [2, 1, 2, 1, 1, 1, 2])
             ).to.be.revertedWith("ComponentNotFound");
         });
 
@@ -128,8 +112,7 @@ describe("ComponentRegistry", function () {
             const user = signers[2];
             const tokenId = 1;
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash, dependencies);
             expect(await componentRegistry.balanceOf(user.address)).to.equal(1);
             expect(await componentRegistry.exists(tokenId)).to.equal(true);
         });
@@ -138,8 +121,8 @@ describe("ComponentRegistry", function () {
             const mechManager = signers[1];
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
-            const component = await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
+            const component = await componentRegistry.connect(mechManager).create(user.address,
+                description, componentHash, dependencies);
             const result = await component.wait();
             expect(result.events[0].event).to.equal("Transfer");
         });
@@ -150,19 +133,15 @@ describe("ComponentRegistry", function () {
             const tokenId = 3;
             const lastDependencies = [1, 2];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash1, description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash1, dependencies);
             const description2 = ethers.utils.id("component description2");
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash2, description2, lastDependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description2, componentHash2, lastDependencies);
 
             let compInfo = await componentRegistry.getInfo(tokenId);
             expect(compInfo.unitOwner).to.equal(user.address);
-            expect(compInfo.developer).to.equal(user.address);
-            expect(compInfo.unitHash.hash).to.equal(componentHash2.hash);
             expect(compInfo.description).to.equal(description2);
+            expect(compInfo.unitHash).to.equal(componentHash2);
             expect(compInfo.numDependencies).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
                 expect(compInfo.dependencies[i]).to.equal(lastDependencies[i]);
@@ -187,10 +166,8 @@ describe("ComponentRegistry", function () {
             const user = signers[2];
             const user2 = signers[3];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
-            await componentRegistry.connect(mechManager).create(user2.address, user2.address,
-                componentHash1, description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash, dependencies);
+            await componentRegistry.connect(mechManager).create(user2.address, description, componentHash1, dependencies);
             await expect(
                 componentRegistry.connect(mechManager).updateHash(user2.address, 1, componentHash2)
             ).to.be.revertedWith("ComponentNotFound");
@@ -205,10 +182,9 @@ describe("ComponentRegistry", function () {
             const user = signers[2];
             const user2 = signers[3];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
-            await componentRegistry.connect(mechManager).create(user2.address, user2.address,
-                componentHash1, description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address,
+                description, componentHash, dependencies);
+            await componentRegistry.connect(mechManager).create(user2.address, description, componentHash1, dependencies);
             await expect(
                 componentRegistry.connect(mechManager).updateHash(user.address, 1, componentHash1)
             ).to.be.revertedWith("HashExists");
@@ -219,8 +195,7 @@ describe("ComponentRegistry", function () {
             const mechManager = signers[1];
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address, description, componentHash, dependencies);
 
             const hashes = await componentRegistry.getUpdatedHashes(2);
             expect(hashes.numHashes).to.equal(0);
@@ -230,15 +205,15 @@ describe("ComponentRegistry", function () {
             const mechManager = signers[1];
             const user = signers[2];
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(user.address, user.address,
-                componentHash, description, dependencies);
+            await componentRegistry.connect(mechManager).create(user.address,
+                description, componentHash, dependencies);
             await componentRegistry.connect(mechManager).updateHash(user.address, 1, componentHash1);
             await componentRegistry.connect(mechManager).updateHash(user.address, 1, componentHash2);
 
             const hashes = await componentRegistry.getUpdatedHashes(1);
             expect(hashes.numHashes).to.equal(2);
-            expect(hashes.unitHashes[0].hash).to.equal(componentHash1.hash);
-            expect(hashes.unitHashes[1].hash).to.equal(componentHash2.hash);
+            expect(hashes.unitHashes[0]).to.equal(componentHash1);
+            expect(hashes.unitHashes[1]).to.equal(componentHash2);
         });
     });
 
@@ -251,31 +226,31 @@ describe("ComponentRegistry", function () {
             // Component 1 (c1)
             salt += "00";
             let hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(user.address, user.address, hash, description, []);
+            await componentRegistry.create(user.address, description, hash, []);
             let subComponents = await componentRegistry.getLocalSubComponents(1);
             expect(subComponents.numSubComponents).to.equal(1);
             // c2
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(user.address, user.address, hash, description, []);
+            await componentRegistry.create(user.address, description, hash, []);
             subComponents = await componentRegistry.getLocalSubComponents(2);
             expect(subComponents.numSubComponents).to.equal(1);
             // c3
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(user.address, user.address, hash, description, [1]);
+            await componentRegistry.create(user.address, description, hash, [1]);
             subComponents = await componentRegistry.getLocalSubComponents(3);
             expect(subComponents.numSubComponents).to.equal(2);
             // c4
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(user.address, user.address, hash, description, [2]);
+            await componentRegistry.create(user.address, description, hash, [2]);
             subComponents = await componentRegistry.getLocalSubComponents(4);
             expect(subComponents.numSubComponents).to.equal(2);
             // c5
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(user.address, user.address, hash, description, [3, 4]);
+            await componentRegistry.create(user.address, description, hash, [3, 4]);
             subComponents = await componentRegistry.getLocalSubComponents(5);
             expect(subComponents.numSubComponents).to.equal(5);
             for (let i = 0; i < subComponents.numSubComponents; i++) {

--- a/test/RegistriesManager.js
+++ b/test/RegistriesManager.js
@@ -44,11 +44,11 @@ describe("RegistriesManager", function () {
 
             // Try minting when paused
             await expect(
-                registriesManager.createComponent(user.address, user.address, componentHashes[0], description, dependencies)
+                registriesManager.createComponent(user.address, description, componentHashes[0], dependencies)
             ).to.be.revertedWith("Paused");
 
             await expect(
-                registriesManager.createAgent(user.address, user.address, componentHashes[0], description, dependencies)
+                registriesManager.createAgent(user.address, description, componentHashes[0], dependencies)
             ).to.be.revertedWith("Paused");
 
             // Unpause the contract
@@ -57,8 +57,8 @@ describe("RegistriesManager", function () {
             // Mint component and agent
             await componentRegistry.changeManager(registriesManager.address);
             await agentRegistry.changeManager(registriesManager.address);
-            await registriesManager.createComponent(user.address, user.address, componentHashes[0], description, dependencies);
-            await registriesManager.createAgent(user.address, user.address, componentHashes[1], description, [1]);
+            await registriesManager.createComponent(user.address, description, componentHashes[0], dependencies);
+            await registriesManager.createAgent(user.address, description, componentHashes[1], [1]);
         });
     });
 
@@ -67,12 +67,12 @@ describe("RegistriesManager", function () {
             const user = signers[1];
             await componentRegistry.changeManager(registriesManager.address);
             await agentRegistry.changeManager(registriesManager.address);
-            await registriesManager.createComponent(user.address, user.address, componentHashes[0], description,
+            await registriesManager.createComponent(user.address, description, componentHashes[0],
                 dependencies);
             await registriesManager.connect(user).updateComponentHash(1, componentHashes[1]);
             await registriesManager.connect(user).updateComponentHash(1, componentHashes[2]);
 
-            await registriesManager.createAgent(user.address, user.address, agentHashes[0], description, [1]);
+            await registriesManager.createAgent(user.address, agentHashes[0], description, [1]);
             await registriesManager.connect(user).updateAgentHash(1, agentHashes[1]);
             await registriesManager.connect(user).updateAgentHash(1, agentHashes[2]);
 

--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -9,7 +9,6 @@ describe("ServiceRegistry", function () {
     let serviceRegistry;
     let gnosisSafeMultisig;
     let signers;
-    const name = ethers.utils.formatBytes32String("service name");
     const description = ethers.utils.formatBytes32String("unit description");
     const configHash = "0x" + "5".repeat(64);
     const configHash1 = "0x" + "6".repeat(64);
@@ -61,7 +60,7 @@ describe("ServiceRegistry", function () {
         signers = await ethers.getSigners();
 
         await componentRegistry.changeManager(signers[0].address);
-        await componentRegistry.create(signers[0].address, signers[0].address, componentHash2, description, []);
+        await componentRegistry.create(signers[0].address, description, componentHash2, []);
     });
 
     context("Initialization", async function () {
@@ -86,7 +85,7 @@ describe("ServiceRegistry", function () {
         it("Should fail when creating a service without a serviceManager", async function () {
             const owner = signers[3].address;
             await expect(
-                serviceRegistry.create(owner, name, description, configHash, agentIds, agentParams, threshold)
+                serviceRegistry.create(owner, description, configHash, agentIds, agentParams, threshold)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -94,19 +93,9 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[3];
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(AddressZero, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(AddressZero, description, configHash, agentIds,
                     agentParams, threshold)
             ).to.be.revertedWith("ZeroAddress");
-        });
-
-        it("Should fail when creating a service with an empty name", async function () {
-            const serviceManager = signers[3];
-            const owner = signers[4].address;
-            await serviceRegistry.changeManager(serviceManager.address);
-            await expect(
-                serviceRegistry.connect(serviceManager).create(owner, ZeroBytes32, description, configHash, agentIds,
-                    agentParams, threshold)
-            ).to.be.revertedWith("ZeroValue");
         });
 
         it("Should fail when creating a service with an empty description", async function () {
@@ -114,7 +103,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, ZeroBytes32, configHash, agentIds, agentParams,
+                serviceRegistry.connect(serviceManager).create(owner, ZeroBytes32, configHash, agentIds, agentParams,
                     threshold)
             ).to.be.revertedWith("ZeroValue");
         });
@@ -124,13 +113,13 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [], [], threshold)
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [], [], threshold)
             ).to.be.revertedWith("WrongArrayLength");
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1], [], threshold)
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1], [], threshold)
             ).to.be.revertedWith("WrongArrayLength");
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1, 3], [[2, regBond]],
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 3], [[2, regBond]],
                     threshold)
             ).to.be.revertedWith("WrongArrayLength");
         });
@@ -140,7 +129,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                     agentParams, threshold)
             ).to.be.revertedWith("WrongAgentId");
         });
@@ -150,10 +139,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1, 1],
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 1],
                     [[2, regBond], [2, regBond]], threshold)
             ).to.be.revertedWith("WrongAgentId");
         });
@@ -163,11 +152,11 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1, 0],
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 0],
                     [[2, regBond], [2, regBond]], threshold)
             ).to.be.revertedWith("WrongAgentId");
         });
@@ -177,11 +166,11 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                     [[3, regBond], [0, regBond]], threshold)
             ).to.be.revertedWith("ZeroValue");
         });
@@ -192,20 +181,20 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
             const minThreshold = Math.floor(maxThreshold * 2 / 3 + 1);
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                     agentParams, minThreshold - 1)
             ).to.be.revertedWith("WrongThreshold");
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                     agentParams, maxThreshold + 1)
             ).to.be.revertedWith("WrongThreshold");
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, minThreshold);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
         });
 
@@ -214,10 +203,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            const service = await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash,
+            const service = await serviceRegistry.connect(serviceManager).create(owner, description, configHash,
                 agentIds, agentParams, maxThreshold);
             const result = await service.wait();
             expect(result.events[1].event).to.equal("CreateService");
@@ -228,10 +217,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             expect(await serviceRegistry.exists(1)).to.equal(true);
         });
@@ -241,7 +230,7 @@ describe("ServiceRegistry", function () {
         it("Should fail when creating a service without a serviceManager", async function () {
             const owner = signers[3].address;
             await expect(
-                serviceRegistry.create(owner, name, description, configHash, agentIds, agentParams, threshold)
+                serviceRegistry.create(owner, description, configHash, agentIds, agentParams, threshold)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -249,7 +238,7 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[3];
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).update(AddressZero, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).update(AddressZero, description, configHash, agentIds,
                     agentParams, threshold, 0)
             ).to.be.revertedWith("ServiceNotFound");
         });
@@ -259,7 +248,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).update(owner, description, configHash, agentIds,
                     agentParams, threshold, 0)
             ).to.be.revertedWith("ServiceNotFound");
         });
@@ -269,12 +258,12 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            const service = await serviceRegistry.connect(serviceManager).update(owner, name, description, configHash,
+            const service = await serviceRegistry.connect(serviceManager).update(owner, description, configHash,
                 agentIds, agentParams, maxThreshold, 1);
             const result = await service.wait();
             expect(result.events[0].event).to.equal("UpdateService");
@@ -289,15 +278,15 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
             await expect(
-                serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).update(owner, description, configHash, agentIds,
                     agentParams, maxThreshold, 1)
             ).to.be.revertedWith("WrongServiceState");
         });
@@ -307,20 +296,20 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // If we update with the same config hash as previous one, it must not be added
-            await serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).update(owner, description, configHash, agentIds,
                 agentParams, maxThreshold, 1);
             let hashes = await serviceRegistry.getPreviousHashes(serviceId);
             expect(hashes.numHashes).to.equal(0);
 
             // Now we are going to have two config hashes
-            await serviceRegistry.connect(serviceManager).update(owner, name, description, configHash1, agentIds,
+            await serviceRegistry.connect(serviceManager).update(owner, description, configHash1, agentIds,
                 agentParams, maxThreshold, 1);
             hashes = await serviceRegistry.getPreviousHashes(serviceId);
             expect(hashes.numHashes).to.equal(1);
@@ -355,10 +344,10 @@ describe("ServiceRegistry", function () {
             const agentInstance = signers[7].address;
 
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond})
@@ -372,10 +361,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
@@ -391,10 +380,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -410,10 +399,10 @@ describe("ServiceRegistry", function () {
             const agentInstances = [signers[7].address, signers[8].address, signers[9].address, signers[10].address];
             const regAgentIds = [agentId, agentId, agentId, agentId];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -428,10 +417,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             const regAgent = await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
@@ -447,12 +436,12 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = [signers[7].address, signers[8].address, signers[9].address];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, {value: regDeposit});
@@ -471,10 +460,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstances = [signers[7].address, signers[8].address];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -512,10 +501,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -529,10 +518,10 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
 
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             const activateService = await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId,
                 {value: regDeposit});
@@ -545,10 +534,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             const terminateService = await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
@@ -566,10 +555,10 @@ describe("ServiceRegistry", function () {
 
             // Create agents and a service
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Activate registration and register and agent instance
@@ -597,11 +586,11 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
@@ -621,13 +610,13 @@ describe("ServiceRegistry", function () {
 
             // Create components
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, [1]);
+            await componentRegistry.connect(mechManager).create(owner, description, componentHash, []);
+            await componentRegistry.connect(mechManager).create(owner, description, componentHash1, [1]);
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1, 2]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1, 2]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -636,7 +625,7 @@ describe("ServiceRegistry", function () {
             let state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1, 2],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 2],
                 [[2, regBond], [1, regBond]], maxThreshold);
             state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(1);
@@ -685,13 +674,13 @@ describe("ServiceRegistry", function () {
 
             // Create components
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash, description, []);
-            await componentRegistry.connect(mechManager).create(owner, owner, componentHash1, description, [1]);
+            await componentRegistry.connect(mechManager).create(owner, description, componentHash, []);
+            await componentRegistry.connect(mechManager).create(owner, description, componentHash1, [1]);
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1, 2]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1, 2]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -700,9 +689,9 @@ describe("ServiceRegistry", function () {
             let state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash1, [2],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash1, [2],
                 [[2, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
@@ -738,8 +727,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[2];
             const owner = signers[3].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
 
             // Initially owner does not have any services
             expect(await serviceRegistry.exists(serviceId)).to.equal(false);
@@ -747,7 +736,7 @@ describe("ServiceRegistry", function () {
 
             // Creating a service
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Initial checks
@@ -757,7 +746,6 @@ describe("ServiceRegistry", function () {
 
             // Check for the service info components
             const serviceInfo = await serviceRegistry.getServiceInfo(serviceId);
-            expect(serviceInfo.name).to.equal(name);
             expect(serviceInfo.description).to.equal(description);
             expect(serviceInfo.numAgentIds).to.equal(agentIds.length);
             expect(serviceInfo.configHash.hash).to.equal(configHash.hash);
@@ -775,18 +763,18 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[2];
             const owner = signers[3].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash2, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash2, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Updating a service
             const newAgentIds = [1, 2, 3];
             const newAgentParams = [[2, regBond], [0, regBond], [1, regBond]];
             const newMaxThreshold = newAgentParams[0][0] + newAgentParams[2][0];
-            await serviceRegistry.connect(serviceManager).update(owner, name, description, configHash, newAgentIds,
+            await serviceRegistry.connect(serviceManager).update(owner, description, configHash, newAgentIds,
                 newAgentParams, newMaxThreshold, serviceId);
 
             // Initial checks
@@ -798,7 +786,6 @@ describe("ServiceRegistry", function () {
 
             // Check for the service info components
             const serviceInfo = await serviceRegistry.getServiceInfo(serviceId);
-            expect(serviceInfo.name).to.equal(name);
             expect(serviceInfo.description).to.equal(description);
             expect(serviceInfo.numAgentIds).to.equal(agentIds.length);
             const agentIdsCheck = [newAgentIds[0], newAgentIds[2]];
@@ -814,7 +801,7 @@ describe("ServiceRegistry", function () {
             expect(agentInstancesInfo.numAgentInstances).to.equal(0);
 
             // Creating a second service and do basic checks
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIdsCheck,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIdsCheck,
                 agentNumSlotsCheck, newMaxThreshold);
             expect(await serviceRegistry.exists(serviceId + 1)).to.equal(true);
             expect(await serviceRegistry.balanceOf(owner)).to.equal(2);
@@ -837,9 +824,9 @@ describe("ServiceRegistry", function () {
             const regAgentIds = [agentId, agentId];
             const maxThreshold = 2;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, agentInstances,
@@ -874,11 +861,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Terminating service without registered agent instances will give it a terminated-unbonded state
@@ -897,11 +884,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
@@ -924,12 +911,12 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating the service
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Activate registration and terminate right after
@@ -950,11 +937,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Revert when insufficient amount is passed
@@ -1007,11 +994,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and try to unbond
@@ -1044,11 +1031,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
@@ -1067,11 +1054,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
@@ -1090,12 +1077,12 @@ describe("ServiceRegistry", function () {
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash1, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Activate registration and register an agent instance
@@ -1124,7 +1111,7 @@ describe("ServiceRegistry", function () {
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -1133,7 +1120,7 @@ describe("ServiceRegistry", function () {
             let state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[1, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
@@ -1182,13 +1169,13 @@ describe("ServiceRegistry", function () {
 
             // Create an agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, owner, agentHash, description, [1]);
+            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
 
             // Create services and activate the agent instance registration
             let state = await serviceRegistry.getServiceState(serviceId);
             expect(state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, name, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});


### PR DESCRIPTION
- Got rid of `name` in service struct;
- Got rid of `developer` field in unit (component, agent) struct;
- Adjusted tests.