### PR TITLE
refactor: addressing a bunch of proposed edits

### DIFF
--- a/contracts/interfaces/IRegistry.sol
+++ b/contracts/interfaces/IRegistry.sol
@@ -4,13 +4,13 @@ pragma solidity ^0.8.14;
 /// @dev Required interface for the component / agent manipulation.
 interface IRegistry {
     /// @dev Creates component / agent.
-    /// @param owner Owner of the component / agent.
+    /// @param unitOwner Owner of the component / agent.
     /// @param description Description of the component / agent.
     /// @param unitHash IPFS hash of the component / agent.
     /// @param dependencies Set of component dependencies in a sorted ascending order.
     /// @return The id of a minted component / agent.
     function create(
-        address owner,
+        address unitOwner,
         bytes32 description,
         bytes32 unitHash,
         uint32[] memory dependencies
@@ -20,35 +20,8 @@ interface IRegistry {
     /// @param owner Owner of the component / agent.
     /// @param unitId Unit Id.
     /// @param unitHash New IPFS hash of the component / agent.
-    function updateHash(address owner, uint256 unitId, bytes32 unitHash) external;
-
-    /// @dev Check for the component / agent existence.
-    /// @param unitId Unit Id.
-    /// @return true if the component / agent exists, false otherwise.
-    function exists(uint256 unitId) external view returns (bool);
-
-    /// @dev Gets the component / agent info.
-    /// @param unitId Unit Id.
-    /// @return owner Owner of the component / agent.
-    /// @return unitHash The primary component / agent IPFS hash.
-    /// @return description The component / agent description.
-    /// @return numDependencies The number of components in the dependency list.
-    /// @return dependencies The list of component dependencies.
-    function getInfo(uint256 unitId) external view returns (
-        address owner,
-        bytes32 unitHash,
-        bytes32 description,
-        uint256 numDependencies,
-        uint32[] memory dependencies
-    );
-
-    /// @dev Gets component / agent dependencies.
-    /// @return numDependencies The number of components in the dependency list.
-    /// @return dependencies The list of component dependencies.
-    function getDependencies(uint256 unitId) external view returns (
-        uint256 numDependencies,
-        uint32[] memory dependencies
-    );
+    /// @return success True, if function executed successfully.
+    function updateHash(address owner, uint256 unitId, bytes32 unitHash) external returns (bool success);
 
     /// @dev Gets subcomponents of a provided unit Id from a local public map.
     /// @param unitId Unit Id.
@@ -70,9 +43,4 @@ interface IRegistry {
     /// @dev Gets the total supply of components / agents.
     /// @return Total supply.
     function totalSupply() external view returns (uint256);
-
-    /// @dev Gets the valid component Id from the provided index.
-    /// @param id Component counter.
-    /// @return componentId Component Id.
-    function tokenByIndex(uint256 id) external view returns (uint256 componentId);
 }

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -27,7 +27,7 @@ module.exports = {
                 settings: {
                     optimizer: {
                         enabled: true,
-                        runs: 1000,
+                        runs: 900,
                     },
                 },
             }

--- a/test/AgentRegistry.js
+++ b/test/AgentRegistry.js
@@ -137,23 +137,29 @@ describe("AgentRegistry", function () {
             const description2 = ethers.utils.id("component description2");
             await agentRegistry.connect(mechManager).create(user.address, description2, agentHash2, lastDependencies);
 
-            let agentInfo = await agentRegistry.getInfo(tokenId);
-            expect(agentInfo.unitOwner).to.equal(user.address);
-            expect(agentInfo.description).to.equal(description2);
-            expect(agentInfo.unitHash).to.equal(agentHash2);
-            expect(agentInfo.numDependencies).to.equal(lastDependencies.length);
+            expect(await agentRegistry.ownerOf(tokenId)).to.equal(user.address);
+            let agentInstance = await agentRegistry.getUnit(tokenId);
+            expect(agentInstance.description).to.equal(description2);
+            expect(agentInstance.unitHash).to.equal(agentHash2);
+            expect(agentInstance.dependencies.length).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
-                expect(agentInfo.dependencies[i]).to.equal(lastDependencies[i]);
+                expect(agentInstance.dependencies[i]).to.equal(lastDependencies[i]);
             }
-            // Getting info about non-existent agent Id
-            agentInfo = await agentRegistry.getInfo(tokenId + 1);
-            expect(agentInfo.unitOwner).to.equal(AddressZero);
 
             let agentDependencies = await agentRegistry.getDependencies(tokenId);
             expect(agentDependencies.numDependencies).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
                 expect(agentDependencies.dependencies[i]).to.equal(lastDependencies[i]);
             }
+
+            // Getting info about non-existent agent Id
+            await expect(
+                agentRegistry.ownerOf(tokenId + 1)
+            ).to.be.revertedWith("NOT_MINTED");
+            agentInstance = await agentRegistry.getUnit(tokenId + 1);
+            expect(agentInstance.description).to.equal("0x" + "0".repeat(64));
+            expect(agentInstance.unitHash).to.equal("0x" + "0".repeat(64));
+            expect(agentInstance.dependencies.length).to.equal(0);
             agentDependencies = await agentRegistry.getDependencies(tokenId + 1);
             expect(agentDependencies.numDependencies).to.equal(0);
         });

--- a/test/ComponentRegistry.js
+++ b/test/ComponentRegistry.js
@@ -138,23 +138,29 @@ describe("ComponentRegistry", function () {
             const description2 = ethers.utils.id("component description2");
             await componentRegistry.connect(mechManager).create(user.address, description2, componentHash2, lastDependencies);
 
-            let compInfo = await componentRegistry.getInfo(tokenId);
-            expect(compInfo.unitOwner).to.equal(user.address);
-            expect(compInfo.description).to.equal(description2);
-            expect(compInfo.unitHash).to.equal(componentHash2);
-            expect(compInfo.numDependencies).to.equal(lastDependencies.length);
+            expect(await componentRegistry.ownerOf(tokenId)).to.equal(user.address);
+            let compInstance = await componentRegistry.getUnit(tokenId);
+            expect(compInstance.description).to.equal(description2);
+            expect(compInstance.unitHash).to.equal(componentHash2);
+            expect(compInstance.dependencies.length).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
-                expect(compInfo.dependencies[i]).to.equal(lastDependencies[i]);
+                expect(compInstance.dependencies[i]).to.equal(lastDependencies[i]);
             }
-            // Getting info about non-existent agent Id
-            compInfo = await componentRegistry.getInfo(tokenId + 1);
-            expect(compInfo.unitOwner).to.equal(AddressZero);
-            
+
             let componentDependencies = await componentRegistry.getDependencies(tokenId);
             expect(componentDependencies.numDependencies).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
                 expect(componentDependencies.dependencies[i]).to.equal(lastDependencies[i]);
             }
+
+            // Getting info about non-existent agent Id
+            await expect(
+                componentRegistry.ownerOf(tokenId + 1)
+            ).to.be.revertedWith("NOT_MINTED");
+            compInstance = await componentRegistry.getUnit(tokenId + 1);
+            expect(compInstance.description).to.equal("0x" + "0".repeat(64));
+            expect(compInstance.unitHash).to.equal("0x" + "0".repeat(64));
+            expect(compInstance.dependencies.length).to.equal(0);
             componentDependencies = await componentRegistry.getDependencies(tokenId + 1);
             expect(componentDependencies.numDependencies).to.equal(0);
         });

--- a/test/RegistriesManager.js
+++ b/test/RegistriesManager.js
@@ -43,12 +43,13 @@ describe("RegistriesManager", function () {
             await registriesManager.pause();
 
             // Try minting when paused
+            // 0 is component, 1 is agent
             await expect(
-                registriesManager.createComponent(user.address, description, componentHashes[0], dependencies)
+                registriesManager.create(0, user.address, description, componentHashes[0], dependencies)
             ).to.be.revertedWith("Paused");
 
             await expect(
-                registriesManager.createAgent(user.address, description, componentHashes[0], dependencies)
+                registriesManager.create(1, user.address, description, componentHashes[0], dependencies)
             ).to.be.revertedWith("Paused");
 
             // Unpause the contract
@@ -57,8 +58,9 @@ describe("RegistriesManager", function () {
             // Mint component and agent
             await componentRegistry.changeManager(registriesManager.address);
             await agentRegistry.changeManager(registriesManager.address);
-            await registriesManager.createComponent(user.address, description, componentHashes[0], dependencies);
-            await registriesManager.createAgent(user.address, description, componentHashes[1], [1]);
+            // 0 is component, 1 is agent
+            await registriesManager.create(0, user.address, description, componentHashes[0], dependencies);
+            await registriesManager.create(1, user.address, description, componentHashes[1], [1]);
         });
     });
 
@@ -67,14 +69,16 @@ describe("RegistriesManager", function () {
             const user = signers[1];
             await componentRegistry.changeManager(registriesManager.address);
             await agentRegistry.changeManager(registriesManager.address);
-            await registriesManager.createComponent(user.address, description, componentHashes[0],
+            // 0 is component, 1 is agent
+            await registriesManager.create(0, user.address, description, componentHashes[0],
                 dependencies);
-            await registriesManager.connect(user).updateComponentHash(1, componentHashes[1]);
-            await registriesManager.connect(user).updateComponentHash(1, componentHashes[2]);
+            await registriesManager.connect(user).updateHash(0, 1, componentHashes[1]);
+            await registriesManager.connect(user).updateHash(0, 1, componentHashes[2]);
 
-            await registriesManager.createAgent(user.address, agentHashes[0], description, [1]);
-            await registriesManager.connect(user).updateAgentHash(1, agentHashes[1]);
-            await registriesManager.connect(user).updateAgentHash(1, agentHashes[2]);
+            // 0 is component, 1 is agent
+            await registriesManager.create(1, user.address, agentHashes[0], description, [1]);
+            await registriesManager.connect(user).updateHash(1, 1, agentHashes[1]);
+            await registriesManager.connect(user).updateHash(1, 1, agentHashes[2]);
 
             const cHashes = await componentRegistry.getUpdatedHashes(1);
             expect(cHashes.numHashes).to.equal(2);


### PR DESCRIPTION
- Addressing several edits stated in comments;

**Suggestion for a function removal**
I propose to leave either this function: 
https://github.com/valory-xyz/autonolas-registries/blob/07be41a48f8d04f2ab17695421b546acf47ad4a0/contracts/ServiceRegistry.sol#L766
or this one:
https://github.com/valory-xyz/autonolas-registries/blob/07be41a48f8d04f2ab17695421b546acf47ad4a0/contracts/ServiceRegistry.sol#L804

With either of those and knowing the set of agent Ids we can cover all of the agent instances. With the first one we can get instances for each agent Id and eventually traverse all of them, with the second function we get all the instances right away, and we can pick the ones we need.