### PR TITLE
refactor: remove description and check for existing hashes

### DIFF
--- a/contracts/RegistriesManager.sol
+++ b/contracts/RegistriesManager.sol
@@ -21,14 +21,12 @@ contract RegistriesManager is GenericManager {
     /// @dev Creates component / agent.
     /// @param unitType Unit type (component or agent).
     /// @param unitOwner Owner of the component / agent.
-    /// @param description Description of the component / agent.
     /// @param unitHash IPFS hash of the component / agent.
     /// @param dependencies Set of component dependencies in a sorted ascending order.
     /// @return unitId The id of a created component / agent.
     function create(
         IRegistry.UnitType unitType,
         address unitOwner,
-        bytes32 description,
         bytes32 unitHash,
         uint32[] memory dependencies
     ) external returns (uint256 unitId)
@@ -38,9 +36,9 @@ contract RegistriesManager is GenericManager {
             revert Paused();
         }
         if (unitType == IRegistry.UnitType.Component) {
-            unitId = IRegistry(componentRegistry).create(unitOwner, description, unitHash, dependencies);
+            unitId = IRegistry(componentRegistry).create(unitOwner, unitHash, dependencies);
         } else {
-            unitId = IRegistry(agentRegistry).create(unitOwner, description, unitHash, dependencies);
+            unitId = IRegistry(agentRegistry).create(unitOwner, unitHash, dependencies);
         }
     }
 

--- a/contracts/ServiceManager.sol
+++ b/contracts/ServiceManager.sol
@@ -19,14 +19,12 @@ contract ServiceManager is GenericManager {
 
     /// @dev Creates a new service.
     /// @param serviceOwner Individual that creates and controls a service.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids.
     /// @param agentParams Number of agent instances and required bond to register an instance in the service.
     /// @param threshold Threshold for a multisig composed by agents.
     function create(
         address serviceOwner,
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         IService.AgentParams[] memory agentParams,
@@ -37,12 +35,11 @@ contract ServiceManager is GenericManager {
         if (paused) {
             revert Paused();
         }
-        return IService(serviceRegistry).create(serviceOwner, description, configHash, agentIds, agentParams,
+        return IService(serviceRegistry).create(serviceOwner, configHash, agentIds, agentParams,
             threshold);
     }
 
     /// @dev Updates a service in a CRUD way.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids.
     /// @param agentParams Number of agent instances and required bond to register an instance in the service.
@@ -50,7 +47,6 @@ contract ServiceManager is GenericManager {
     /// @param serviceId Service Id to be updated.
     /// @return success True, if function executed successfully.
     function update(
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         IService.AgentParams[] memory agentParams,
@@ -58,7 +54,7 @@ contract ServiceManager is GenericManager {
         uint256 serviceId
     ) external returns (bool)
     {
-        return IService(serviceRegistry).update(msg.sender, description, configHash, agentIds, agentParams,
+        return IService(serviceRegistry).update(msg.sender, configHash, agentIds, agentParams,
             threshold, serviceId);
     }
 

--- a/contracts/ServiceRegistry.sol
+++ b/contracts/ServiceRegistry.sol
@@ -52,8 +52,6 @@ contract ServiceRegistry is GenericRegistry {
         uint96 securityDeposit;
         // Multisig address for agent instances
         address multisig;
-        // Service description
-        bytes32 description;
         // IPFS hashes pointing to the config metadata
         bytes32 configHash;
         // Agent instance signers threshold: must no less than ceil((n * 2 + 1) / 3) of all the agent instances combined
@@ -111,22 +109,15 @@ contract ServiceRegistry is GenericRegistry {
     }
 
     /// @dev Going through basic initial service checks.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids.
     /// @param agentParams Number of agent instances and required required bond to register an instance in the service.
     function _initialChecks(
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         AgentParams[] memory agentParams
     ) private view
     {
-        // Checks for non-empty description
-        if(description == 0) {
-            revert ZeroValue();
-        }
-
         // Check for the non-zero hash value
         if (configHash == 0) {
             revert ZeroValue();
@@ -198,7 +189,6 @@ contract ServiceRegistry is GenericRegistry {
 
     /// @dev Creates a new service.
     /// @param serviceOwner Individual that creates and controls a service.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids in a sorted ascending order.
     /// @param agentParams Number of agent instances and required required bond to register an instance in the service.
@@ -206,7 +196,6 @@ contract ServiceRegistry is GenericRegistry {
     /// @return serviceId Created service Id.
     function create(
         address serviceOwner,
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         AgentParams[] memory agentParams,
@@ -230,7 +219,7 @@ contract ServiceRegistry is GenericRegistry {
         }
 
         // Execute initial checks
-        _initialChecks(description, configHash, agentIds, agentParams);
+        _initialChecks(configHash, agentIds, agentParams);
 
         // Check that there are no zero number of slots for a specific canonical agent id and no zero registration bond
         for (uint256 i = 0; i < agentIds.length; i++) {
@@ -246,7 +235,6 @@ contract ServiceRegistry is GenericRegistry {
         // Set high-level data components of the service instance
         Service memory service;
         // Updating high-level data components of the service
-        service.description = description;
         service.threshold = threshold;
         // Assigning the initial hash
         service.configHash = configHash;
@@ -268,7 +256,6 @@ contract ServiceRegistry is GenericRegistry {
 
     /// @dev Updates a service in a CRUD way.
     /// @param serviceOwner Individual that creates and controls a service.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids in a sorted ascending order.
     /// @param agentParams Number of agent instances and required required bond to register an instance in the service.
@@ -277,7 +264,6 @@ contract ServiceRegistry is GenericRegistry {
     /// @return success True, if function executed successfully.
     function update(
         address serviceOwner,
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         AgentParams[] memory agentParams,
@@ -302,10 +288,9 @@ contract ServiceRegistry is GenericRegistry {
         }
 
         // Execute initial checks
-        _initialChecks(description, configHash, agentIds, agentParams);
+        _initialChecks(configHash, agentIds, agentParams);
 
         // Updating high-level data components of the service
-        service.description = description;
         service.threshold = threshold;
         service.maxNumAgentInstances = 0;
 

--- a/contracts/UnitRegistry.sol
+++ b/contracts/UnitRegistry.sol
@@ -16,8 +16,6 @@ abstract contract UnitRegistry is GenericRegistry {
 
     // Unit parameters
     struct Unit {
-        // Description of the unit
-        bytes32 description;
         // Primary IPFS hash of the unit
         bytes32 unitHash;
         // Set of component dependencies (agents are also based on components)
@@ -29,8 +27,6 @@ abstract contract UnitRegistry is GenericRegistry {
     UnitType public immutable unitType;
     // Map of unit Id => set of updated IPFS hashes
     mapping(uint256 => bytes32[]) public mapUnitIdHashes;
-    // Map of IPFS hash => unit Id
-    mapping(bytes32 => uint32) public mapHashUnitId;
     // Map of unit Id => set of subcomponents (possible to derive from any registry)
     mapping(uint256 => uint32[]) public mapSubComponents;
     // Map of unit Id => unit
@@ -47,11 +43,10 @@ abstract contract UnitRegistry is GenericRegistry {
 
     /// @dev Creates unit.
     /// @param unitOwner Owner of the unit.
-    /// @param description Description of the unit.
     /// @param unitHash IPFS CID hash of the unit.
     /// @param dependencies Set of unit dependencies in a sorted ascending order (unit Ids).
     /// @return unitId The id of a minted unit.
-    function create(address unitOwner, bytes32 description, bytes32 unitHash, uint32[] memory dependencies)
+    function create(address unitOwner, bytes32 unitHash, uint32[] memory dependencies)
         external virtual returns (uint256 unitId)
     {
         // Reentrancy guard
@@ -74,16 +69,6 @@ abstract contract UnitRegistry is GenericRegistry {
         if (unitHash == 0) {
             revert ZeroValue();
         }
-
-        // Check for the existent IPFS hashes
-        if (mapHashUnitId[unitHash] > 0) {
-            revert HashExists();
-        }
-
-        // Checks for non-empty description and unit dependency
-        if (description == 0) {
-            revert ZeroValue();
-        }
         
         // Check for dependencies validity: must be already allocated, must not repeat
         unitId = totalSupply;
@@ -94,10 +79,8 @@ abstract contract UnitRegistry is GenericRegistry {
 
         // Initialize the unit and mint its token
         Unit storage unit = mapUnits[unitId];
-        unit.description = description;
         unit.unitHash = unitHash;
         unit.dependencies = dependencies;
-        mapHashUnitId[unitHash] = uint32(unitId);
 
         // Update the map of subcomponents with calculated subcomponents for the new unit Id
         // In order to get the correct set of subcomponents, we need to differentiate between the callers of this function
@@ -153,11 +136,6 @@ abstract contract UnitRegistry is GenericRegistry {
         // Check for the hash value
         if (unitHash == 0) {
             revert ZeroValue();
-        }
-
-        // Check for the existent IPFS hashes
-        if (mapHashUnitId[unitHash] > 0) {
-            revert HashExists();
         }
 
         mapUnitIdHashes[unitId].push(unitHash);

--- a/contracts/interfaces/IRegistry.sol
+++ b/contracts/interfaces/IRegistry.sol
@@ -10,13 +10,11 @@ interface IRegistry {
 
     /// @dev Creates component / agent.
     /// @param unitOwner Owner of the component / agent.
-    /// @param description Description of the component / agent.
     /// @param unitHash IPFS hash of the component / agent.
     /// @param dependencies Set of component dependencies in a sorted ascending order.
     /// @return The id of a minted component / agent.
     function create(
         address unitOwner,
-        bytes32 description,
         bytes32 unitHash,
         uint32[] memory dependencies
     ) external returns (uint256);

--- a/contracts/interfaces/IService.sol
+++ b/contracts/interfaces/IService.sol
@@ -12,7 +12,6 @@ interface IService{
 
     /// @dev Creates a new service.
     /// @param serviceOwner Individual that creates and controls a service.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids in a sorted ascending order.
     /// @param agentParams Number of agent instances and required bond to register an instance in the service.
@@ -20,7 +19,6 @@ interface IService{
     /// @return serviceId Created service Id.
     function create(
         address serviceOwner,
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         AgentParams[] memory agentParams,
@@ -29,7 +27,6 @@ interface IService{
 
     /// @dev Updates a service in a CRUD way.
     /// @param serviceOwner Individual that creates and controls a service.
-    /// @param description Description of the service.
     /// @param configHash IPFS hash pointing to the config metadata.
     /// @param agentIds Canonical agent Ids in a sorted ascending order.
     /// @param agentParams Number of agent instances and required bond to register an instance in the service.
@@ -38,7 +35,6 @@ interface IService{
     /// @return success True, if function executed successfully.
     function update(
         address serviceOwner,
-        bytes32 description,
         bytes32 configHash,
         uint32[] memory agentIds,
         AgentParams[] memory agentParams,

--- a/test/AgentRegistry.js
+++ b/test/AgentRegistry.js
@@ -7,7 +7,6 @@ describe("AgentRegistry", function () {
     let componentRegistry;
     let agentRegistry;
     let signers;
-    const description = ethers.utils.formatBytes32String("agent description");
     const componentHash = "0x" + "5".repeat(64);
     const agentHash = "0x" + "9".repeat(64);
     const agentHash1 = "0x" + "1".repeat(64);
@@ -27,7 +26,7 @@ describe("AgentRegistry", function () {
         signers = await ethers.getSigners();
 
         await componentRegistry.changeManager(signers[0].address);
-        await componentRegistry.create(signers[0].address, description, componentHash, []);
+        await componentRegistry.create(signers[0].address, componentHash, []);
     });
 
     context("Initialization", async function () {
@@ -58,7 +57,7 @@ describe("AgentRegistry", function () {
         it("Should fail when creating an agent without a mechManager", async function () {
             const user = signers[2];
             await expect(
-                agentRegistry.create(user.address, description, agentHash, dependencies)
+                agentRegistry.create(user.address, agentHash, dependencies)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -66,27 +65,8 @@ describe("AgentRegistry", function () {
             const mechManager = signers[1];
             await agentRegistry.changeManager(mechManager.address);
             await expect(
-                agentRegistry.connect(mechManager).create(AddressZero, description, agentHash, dependencies)
+                agentRegistry.connect(mechManager).create(AddressZero, agentHash, dependencies)
             ).to.be.revertedWith("ZeroAddress");
-        });
-
-        it("Should fail when creating an agent with an empty description", async function () {
-            const mechManager = signers[1];
-            const user = signers[2];
-            await agentRegistry.changeManager(mechManager.address);
-            await expect(
-                agentRegistry.connect(mechManager).create(user.address, "0x" + "0".repeat(64), agentHash, dependencies)
-            ).to.be.revertedWith("ZeroValue");
-        });
-
-        it("Should fail when creating a second agent with the same hash", async function () {
-            const mechManager = signers[1];
-            const user = signers[2];
-            await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(user.address, description, agentHash, dependencies);
-            await expect(
-                agentRegistry.connect(mechManager).create(user.address, description, agentHash, dependencies)
-            ).to.be.revertedWith("HashExists");
         });
 
         it("Should fail when component number is less or equal to zero", async function () {
@@ -94,7 +74,7 @@ describe("AgentRegistry", function () {
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
             await expect(
-                agentRegistry.connect(mechManager).create(user.address, description, agentHash, [0])
+                agentRegistry.connect(mechManager).create(user.address, agentHash, [0])
             ).to.be.revertedWith("ComponentNotFound");
         });
 
@@ -103,7 +83,7 @@ describe("AgentRegistry", function () {
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
             await expect(
-                agentRegistry.connect(mechManager).create(user.address, description, agentHash, [2])
+                agentRegistry.connect(mechManager).create(user.address, agentHash, [2])
             ).to.be.revertedWith("ComponentNotFound");
         });
 
@@ -113,7 +93,7 @@ describe("AgentRegistry", function () {
             const tokenId = 1;
             await agentRegistry.changeManager(mechManager.address);
             await agentRegistry.connect(mechManager).create(user.address,
-                description, agentHash, dependencies);
+                agentHash, dependencies);
             expect(await agentRegistry.balanceOf(user.address)).to.equal(1);
             expect(await agentRegistry.exists(tokenId)).to.equal(true);
         });
@@ -122,7 +102,7 @@ describe("AgentRegistry", function () {
             const mechManager = signers[1];
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
-            const agent = await agentRegistry.connect(mechManager).create(user.address, description, agentHash, dependencies);
+            const agent = await agentRegistry.connect(mechManager).create(user.address, agentHash, dependencies);
             const result = await agent.wait();
             expect(result.events[0].event).to.equal("Transfer");
         });
@@ -132,14 +112,12 @@ describe("AgentRegistry", function () {
             const user = signers[2];
             const tokenId = 1;
             const lastDependencies = [1, 2];
-            await componentRegistry.create(user.address, description, agentHash, []);
+            await componentRegistry.create(user.address, agentHash, []);
             await agentRegistry.changeManager(mechManager.address);
-            const description2 = ethers.utils.id("component description2");
-            await agentRegistry.connect(mechManager).create(user.address, description2, agentHash2, lastDependencies);
+            await agentRegistry.connect(mechManager).create(user.address, agentHash2, lastDependencies);
 
             expect(await agentRegistry.ownerOf(tokenId)).to.equal(user.address);
             let agentInstance = await agentRegistry.getUnit(tokenId);
-            expect(agentInstance.description).to.equal(description2);
             expect(agentInstance.unitHash).to.equal(agentHash2);
             expect(agentInstance.dependencies.length).to.equal(lastDependencies.length);
             for (let i = 0; i < lastDependencies.length; i++) {
@@ -157,7 +135,6 @@ describe("AgentRegistry", function () {
                 agentRegistry.ownerOf(tokenId + 1)
             ).to.be.revertedWith("NOT_MINTED");
             agentInstance = await agentRegistry.getUnit(tokenId + 1);
-            expect(agentInstance.description).to.equal("0x" + "0".repeat(64));
             expect(agentInstance.unitHash).to.equal("0x" + "0".repeat(64));
             expect(agentInstance.dependencies.length).to.equal(0);
             agentDependencies = await agentRegistry.getDependencies(tokenId + 1);
@@ -169,7 +146,7 @@ describe("AgentRegistry", function () {
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
             await expect(
-                agentRegistry.connect(mechManager).create(user.address, description, agentHash, [])
+                agentRegistry.connect(mechManager).create(user.address, agentHash, [])
             ).to.be.revertedWith("ZeroValue");
         });
     });
@@ -181,9 +158,9 @@ describe("AgentRegistry", function () {
             const user2 = signers[3];
             await agentRegistry.changeManager(mechManager.address);
             await agentRegistry.connect(mechManager).create(user.address,
-                description, agentHash, dependencies);
+                agentHash, dependencies);
             await agentRegistry.connect(mechManager).create(user2.address,
-                description, agentHash1, dependencies);
+                agentHash1, dependencies);
             await expect(
                 agentRegistry.connect(mechManager).updateHash(user2.address, 1, agentHash2)
             ).to.be.revertedWith("AgentNotFound");
@@ -193,25 +170,11 @@ describe("AgentRegistry", function () {
             await agentRegistry.connect(mechManager).updateHash(user.address, 1, agentHash2);
         });
 
-        it("Should fail when the updated hash already exists", async function () {
-            const mechManager = signers[1];
-            const user = signers[2];
-            const user2 = signers[3];
-            await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(user.address,
-                description, agentHash, dependencies);
-            await agentRegistry.connect(mechManager).create(user2.address, description, agentHash1, dependencies);
-            await expect(
-                agentRegistry.connect(mechManager).updateHash(user.address, 1, agentHash1)
-            ).to.be.revertedWith("HashExists");
-            await agentRegistry.connect(mechManager).updateHash(user.address, 1, agentHash2);
-        });
-
         it("Should return zeros when getting hashes of non-existent agent", async function () {
             const mechManager = signers[1];
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(user.address, description, agentHash, dependencies);
+            await agentRegistry.connect(mechManager).create(user.address, agentHash, dependencies);
 
             const hashes = await agentRegistry.getUpdatedHashes(2);
             expect(hashes.numHashes).to.equal(0);
@@ -222,7 +185,7 @@ describe("AgentRegistry", function () {
             const user = signers[2];
             await agentRegistry.changeManager(mechManager.address);
             await agentRegistry.connect(mechManager).create(user.address,
-                description, agentHash, dependencies);
+                agentHash, dependencies);
             await agentRegistry.connect(mechManager).updateHash(user.address, 1, agentHash1);
             await agentRegistry.connect(mechManager).updateHash(user.address, 1, agentHash2);
 
@@ -249,9 +212,9 @@ describe("AgentRegistry", function () {
                 salt += "00";
                 hash = ethers.utils.keccak256(salt);
                 // Create a component based on a previously created component
-                await componentRegistry.create(user.address, description, hash, [i]);
+                await componentRegistry.create(user.address, hash, [i]);
                 // Create an agent based on a previously created component
-                await agentRegistry.create(user.address, description, hash, [i + 1]);
+                await agentRegistry.create(user.address, hash, [i + 1]);
                 // Check for the obtained subcomponents for a created component
                 let regSubComponents = await agentRegistry.getLocalSubComponents(i);
                 expect(regSubComponents.numSubComponents).to.equal(i + 1);
@@ -273,7 +236,7 @@ describe("AgentRegistry", function () {
             let hash = ethers.utils.keccak256(salt);
             // Creating one more component without dependencies
             // Note that one component already exists (defined in beforeEach())
-            await componentRegistry.create(user.address, description, hash, []);
+            await componentRegistry.create(user.address, hash, []);
             // For each 2 components, create a new one based on all the correspondent previously created components
             // c1 => [c1]; c2 => [c2]; c3 => [c1, c3]; c4 => [c2, c4]; etc
             for (let i = 1; i < numComponents; i += 2) {
@@ -281,9 +244,9 @@ describe("AgentRegistry", function () {
                     salt += "00";
                     hash = ethers.utils.keccak256(salt);
                     // Create a component based on a previously created component
-                    await componentRegistry.create(user.address, description, hash, [i + j]);
+                    await componentRegistry.create(user.address, hash, [i + j]);
                     // Create an agent based on a previously created component
-                    await agentRegistry.create(user.address, description, hash, [i + j]);
+                    await agentRegistry.create(user.address, hash, [i + j]);
                     // Check for the obtained subcomponents for a created component
                     let regSubComponents = await agentRegistry.getLocalSubComponents(i + j);
                     expect(regSubComponents.numSubComponents).to.equal((i + 1) / 2);

--- a/test/RegistriesManager.js
+++ b/test/RegistriesManager.js
@@ -8,7 +8,6 @@ describe("RegistriesManager", function () {
     let agentRegistry;
     let registriesManager;
     let signers;
-    const description = ethers.utils.formatBytes32String("unit description");
     const componentHashes = ["0x" + "9".repeat(64), "0x" + "1".repeat(64), "0x" + "2".repeat(64)];
     const agentHashes = ["0x" + "5".repeat(64), "0x" + "6".repeat(64), "0x" + "7".repeat(64)];
     const dependencies = [];
@@ -50,11 +49,11 @@ describe("RegistriesManager", function () {
             // Try minting when paused
             // 0 is component, 1 is agent
             await expect(
-                registriesManager.create(0, user.address, description, componentHashes[0], dependencies)
+                registriesManager.create(0, user.address, componentHashes[0], dependencies)
             ).to.be.revertedWith("Paused");
 
             await expect(
-                registriesManager.create(1, user.address, description, componentHashes[0], dependencies)
+                registriesManager.create(1, user.address, componentHashes[0], dependencies)
             ).to.be.revertedWith("Paused");
 
             // Try to unpause not from the owner of the service manager
@@ -69,8 +68,8 @@ describe("RegistriesManager", function () {
             await componentRegistry.changeManager(registriesManager.address);
             await agentRegistry.changeManager(registriesManager.address);
             // 0 is component, 1 is agent
-            await registriesManager.create(0, user.address, description, componentHashes[0], dependencies);
-            await registriesManager.create(1, user.address, description, componentHashes[1], [1]);
+            await registriesManager.create(0, user.address, componentHashes[0], dependencies);
+            await registriesManager.create(1, user.address, componentHashes[1], [1]);
         });
     });
 
@@ -80,13 +79,13 @@ describe("RegistriesManager", function () {
             await componentRegistry.changeManager(registriesManager.address);
             await agentRegistry.changeManager(registriesManager.address);
             // 0 is component, 1 is agent
-            await registriesManager.create(0, user.address, description, componentHashes[0],
+            await registriesManager.create(0, user.address, componentHashes[0],
                 dependencies);
             await registriesManager.connect(user).updateHash(0, 1, componentHashes[1]);
             await registriesManager.connect(user).updateHash(0, 1, componentHashes[2]);
 
             // 0 is component, 1 is agent
-            await registriesManager.create(1, user.address, agentHashes[0], description, [1]);
+            await registriesManager.create(1, user.address, agentHashes[0], [1]);
             await registriesManager.connect(user).updateHash(1, 1, agentHashes[1]);
             await registriesManager.connect(user).updateHash(1, 1, agentHashes[2]);
 

--- a/test/ServiceManager.js
+++ b/test/ServiceManager.js
@@ -12,7 +12,6 @@ describe("ServiceRegistry integration", function () {
     let serviceManager;
     let gnosisSafeMultisig;
     let signers;
-    const description = ethers.utils.formatBytes32String("service description");
     const configHash = "0x" + "5".repeat(64);
     const regBond = 1000;
     const regDeposit = 1000;
@@ -62,7 +61,7 @@ describe("ServiceRegistry integration", function () {
 
         signers = await ethers.getSigners();
         await componentRegistry.changeManager(signers[0].address);
-        await componentRegistry.create(signers[0].address, description, unitHash3, []);
+        await componentRegistry.create(signers[0].address, unitHash3, []);
     });
 
     context("Service creation via manager", async function () {
@@ -94,8 +93,8 @@ describe("ServiceRegistry integration", function () {
             const manager = signers[2];
 
             await agentRegistry.changeManager(manager.address);
-            await agentRegistry.connect(manager).create(owner, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner, description, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Try to pause not from the owner of the service manager
@@ -109,7 +108,7 @@ describe("ServiceRegistry integration", function () {
             // Try minting when paused
             // 0 is component, 1 is agent
             await expect(
-                serviceManager.create(owner, description, configHash, agentIds, agentParams, maxThreshold)
+                serviceManager.create(owner, configHash, agentIds, agentParams, maxThreshold)
             ).to.be.revertedWith("Paused");
 
             // Try to unpause not from the owner of the service manager
@@ -121,13 +120,13 @@ describe("ServiceRegistry integration", function () {
             await serviceManager.unpause();
 
             // Mint component and agent
-            await serviceManager.create(owner, description, configHash, agentIds, agentParams, maxThreshold);
+            await serviceManager.create(owner, configHash, agentIds, agentParams, maxThreshold);
         });
 
         it("Should fail when creating a service without a manager being white listed", async function () {
             const owner = signers[4].address;
             await expect(
-                serviceManager.create(owner, description, configHash, agentIds, agentParams, threshold)
+                serviceManager.create(owner, configHash, agentIds, agentParams, threshold)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -135,10 +134,10 @@ describe("ServiceRegistry integration", function () {
             const manager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(manager.address);
-            await agentRegistry.connect(manager).create(owner, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner, description, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceManager.create(owner, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner, configHash, agentIds, agentParams,
                 maxThreshold);
             expect(await serviceRegistry.exists(serviceIds[0])).to.equal(true);
         });
@@ -149,12 +148,12 @@ describe("ServiceRegistry integration", function () {
             const operator = signers[6];
             const agentInstances = [signers[7].address, signers[8].address, signers[9].address];
             await agentRegistry.changeManager(manager.address);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
             await serviceManager.connect(owner).activateRegistration(serviceIds[0], {value: regDeposit});
             await serviceManager.connect(owner).activateRegistration(serviceIds[1], {value: regDeposit});
@@ -171,7 +170,7 @@ describe("ServiceRegistry integration", function () {
             const owner = signers[3];
 
             await agentRegistry.changeManager(manager.address);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Pause the contract
@@ -179,14 +178,14 @@ describe("ServiceRegistry integration", function () {
 
             // Try creating a contract when paused
             await expect(
-                serviceManager.create(owner.address, description, configHash, [1], [[1, regBond]], 1)
+                serviceManager.create(owner.address, configHash, [1], [[1, regBond]], 1)
             ).to.be.revertedWith("Paused");
 
             // Unpause the contract
             await serviceManager.unpause();
 
             // Create a service
-            await serviceManager.create(owner.address, description, configHash, [1], [[1, regBond]], 1);
+            await serviceManager.create(owner.address, configHash, [1], [[1, regBond]], 1);
         });
     });
     
@@ -195,15 +194,15 @@ describe("ServiceRegistry integration", function () {
             const manager = signers[4];
             const owner = signers[5];
             await agentRegistry.changeManager(manager.address);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash1, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash2, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash2, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.connect(owner).update(description, configHash, [1, 2, 3],
+            await serviceManager.connect(owner).update(configHash, [1, 2, 3],
                 [[3, regBond], [0, regBond], [4, regBond]], maxThreshold, serviceIds[0]);
             expect(await serviceRegistry.exists(2)).to.equal(true);
             expect(await serviceRegistry.exists(3)).to.equal(false);
@@ -219,22 +218,22 @@ describe("ServiceRegistry integration", function () {
             await agentRegistry.changeManager(manager.address);
 
             // Creating 3 canonical agents
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash1, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash2, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash2, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating two services
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
 
             // Updating service Id == 1
             const newAgentIds = [1, 2, 3];
             const newAgentParams = [[2, regBond], [0, regBond], [1, regBond]];
             const newMaxThreshold = newAgentParams[0][0] + newAgentParams[2][0];
-            await serviceManager.connect(owner).update(description, configHash, newAgentIds,
+            await serviceManager.connect(owner).update(configHash, newAgentIds,
                 newAgentParams, newMaxThreshold, serviceIds[0]);
             let service = await serviceRegistry.getService(serviceIds[0]);
             expect(service.state).to.equal(1);
@@ -247,7 +246,7 @@ describe("ServiceRegistry integration", function () {
 
             // Fail when trying to update the service again, even though no agent instances are registered yet
             await expect(
-                serviceManager.connect(owner).update(description, configHash, newAgentIds,
+                serviceManager.connect(owner).update(configHash, newAgentIds,
                     newAgentParams, newMaxThreshold, serviceIds[0])
             ).to.be.revertedWith("WrongServiceState");
 
@@ -285,15 +284,15 @@ describe("ServiceRegistry integration", function () {
             await agentRegistry.changeManager(manager.address);
 
             // Creating 2 canonical agents
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating a service
             const newAgentIds = [1, 2];
             const newAgentParams = [[2, regBond], [1, regBond]];
             const newMaxThreshold = newAgentParams[0][0] + newAgentParams[1][0];
-            await serviceManager.create(owner.address, description, configHash, newAgentIds,
+            await serviceManager.create(owner.address, configHash, newAgentIds,
                 newAgentParams, newMaxThreshold);
             await serviceManager.connect(owner).activateRegistration(serviceIds[0], {value: regDeposit});
 
@@ -348,14 +347,14 @@ describe("ServiceRegistry integration", function () {
             await agentRegistry.changeManager(manager.address);
 
             // Creating 2 canonical agents
-            await agentRegistry.connect(manager).create(owner, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner, description, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating two services
-            await serviceManager.create(owner, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.create(owner, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner, configHash, agentIds, agentParams,
                 maxThreshold);
 
             // Initial checks
@@ -400,10 +399,10 @@ describe("ServiceRegistry integration", function () {
             const agentInstances = [signers[6].address, signers[7].address];
             const maxThreshold = 2;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner.address, description, unitHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner.address, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceManager.connect(owner).create(owner.address, description, configHash, [agentIds[0]],
+            await serviceManager.connect(owner).create(owner.address, configHash, [agentIds[0]],
                 [[maxThreshold, regBond]], maxThreshold);
 
             // Activate agent instance registration and register an agent instance
@@ -435,17 +434,17 @@ describe("ServiceRegistry integration", function () {
             const manager = signers[4];
             const owner = signers[5];
             await agentRegistry.changeManager(manager.address);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash1, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash2, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash2, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
-            await serviceManager.create(owner.address, description, configHash, agentIds, agentParams,
+            await serviceManager.create(owner.address, configHash, agentIds, agentParams,
                 maxThreshold);
             await serviceManager.connect(owner).activateRegistration(serviceIds[0], {value: regDeposit});
             await serviceManager.connect(owner).terminate(serviceIds[0]);
-            await serviceManager.connect(owner).update(description, configHash, [1, 2, 3],
+            await serviceManager.connect(owner).update(configHash, [1, 2, 3],
                 [[3, regBond], [0, regBond], [4, regBond]], maxThreshold, serviceIds[0]);
         });
     });
@@ -459,12 +458,12 @@ describe("ServiceRegistry integration", function () {
             await agentRegistry.changeManager(manager.address);
 
             // Creating 2 canonical agents
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash, [1]);
-            await agentRegistry.connect(manager).create(owner.address, description, unitHash1, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash, [1]);
+            await agentRegistry.connect(manager).create(owner.address, unitHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating a service and activating registration
-            await serviceManager.create(owner.address, description, configHash, [1], [[1, regBond]], 1);
+            await serviceManager.create(owner.address, configHash, [1], [[1, regBond]], 1);
             await serviceManager.connect(owner).activateRegistration(serviceIds[0], {value: regDeposit});
 
             // Registering agent instance

--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -10,7 +10,6 @@ describe("ServiceRegistry", function () {
     let gnosisSafeMultisig;
     let reentrancyAttacker;
     let signers;
-    const description = ethers.utils.formatBytes32String("unit description");
     const configHash = "0x" + "5".repeat(64);
     const configHash1 = "0x" + "6".repeat(64);
     const regBond = 1000;
@@ -67,7 +66,7 @@ describe("ServiceRegistry", function () {
         signers = await ethers.getSigners();
 
         await componentRegistry.changeManager(signers[0].address);
-        await componentRegistry.create(signers[0].address, description, componentHash3, []);
+        await componentRegistry.create(signers[0].address, componentHash3, []);
     });
 
     context("Initialization", async function () {
@@ -123,7 +122,7 @@ describe("ServiceRegistry", function () {
         it("Should fail when creating a service without a serviceManager", async function () {
             const owner = signers[3].address;
             await expect(
-                serviceRegistry.create(owner, description, configHash, agentIds, agentParams, threshold)
+                serviceRegistry.create(owner, configHash, agentIds, agentParams, threshold)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -143,19 +142,9 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[3];
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(AddressZero, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(AddressZero, configHash, agentIds,
                     agentParams, threshold)
             ).to.be.revertedWith("ZeroAddress");
-        });
-
-        it("Should fail when creating a service with a zero value description", async function () {
-            const serviceManager = signers[3];
-            const owner = signers[4].address;
-            await serviceRegistry.changeManager(serviceManager.address);
-            await expect(
-                serviceRegistry.connect(serviceManager).create(owner, ZeroBytes32, configHash, agentIds, agentParams,
-                    threshold)
-            ).to.be.revertedWith("ZeroValue");
         });
 
         it("Should fail when creating a service with a zero value config hash", async function () {
@@ -163,7 +152,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, ZeroBytes32, agentIds, agentParams,
+                serviceRegistry.connect(serviceManager).create(owner, ZeroBytes32, agentIds, agentParams,
                     threshold)
             ).to.be.revertedWith("ZeroValue");
         });
@@ -173,13 +162,13 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [], [], threshold)
+                serviceRegistry.connect(serviceManager).create(owner, configHash, [], [], threshold)
             ).to.be.revertedWith("WrongArrayLength");
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1], [], threshold)
+                serviceRegistry.connect(serviceManager).create(owner, configHash, [1], [], threshold)
             ).to.be.revertedWith("WrongArrayLength");
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 3], [[2, regBond]],
+                serviceRegistry.connect(serviceManager).create(owner, configHash, [1, 3], [[2, regBond]],
                     threshold)
             ).to.be.revertedWith("WrongArrayLength");
         });
@@ -189,7 +178,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                     agentParams, threshold)
             ).to.be.revertedWith("WrongAgentId");
         });
@@ -199,10 +188,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 1],
+                serviceRegistry.connect(serviceManager).create(owner, configHash, [1, 1],
                     [[2, regBond], [2, regBond]], threshold)
             ).to.be.revertedWith("WrongAgentId");
         });
@@ -212,11 +201,11 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 0],
+                serviceRegistry.connect(serviceManager).create(owner, configHash, [1, 0],
                     [[2, regBond], [2, regBond]], threshold)
             ).to.be.revertedWith("WrongAgentId");
         });
@@ -226,11 +215,11 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                     [[3, regBond], [0, regBond]], threshold)
             ).to.be.revertedWith("ZeroValue");
         });
@@ -241,20 +230,20 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
             const minThreshold = Math.floor(maxThreshold * 2 / 3 + 1);
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                     agentParams, minThreshold - 1)
             ).to.be.revertedWith("WrongThreshold");
             await expect(
-                serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                     agentParams, maxThreshold + 1)
             ).to.be.revertedWith("WrongThreshold");
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, minThreshold);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
         });
 
@@ -263,10 +252,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            const service = await serviceRegistry.connect(serviceManager).create(owner, description, configHash,
+            const service = await serviceRegistry.connect(serviceManager).create(owner, configHash,
                 agentIds, agentParams, maxThreshold);
             const result = await service.wait();
             expect(result.events[1].event).to.equal("CreateService");
@@ -277,10 +266,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             expect(await serviceRegistry.exists(1)).to.equal(true);
         });
@@ -290,10 +279,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash,
                 agentIds, agentParams, maxThreshold);
             expect(await serviceRegistry.tokenURI(serviceId)).to.equal("https://localhost/service/1");
         });
@@ -303,10 +292,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash,
                 agentIds, agentParams, maxThreshold);
             await expect(
                 serviceRegistry.tokenByIndex(1)
@@ -319,7 +308,7 @@ describe("ServiceRegistry", function () {
         it("Should fail when creating a service without a serviceManager", async function () {
             const owner = signers[3].address;
             await expect(
-                serviceRegistry.create(owner, description, configHash, agentIds, agentParams, threshold)
+                serviceRegistry.create(owner, configHash, agentIds, agentParams, threshold)
             ).to.be.revertedWith("ManagerOnly");
         });
 
@@ -327,7 +316,7 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[3];
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).update(AddressZero, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).update(AddressZero, configHash, agentIds,
                     agentParams, threshold, 0)
             ).to.be.revertedWith("NOT_MINTED");
         });
@@ -337,7 +326,7 @@ describe("ServiceRegistry", function () {
             const owner = signers[4].address;
             await serviceRegistry.changeManager(serviceManager.address);
             await expect(
-                serviceRegistry.connect(serviceManager).update(owner, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).update(owner, configHash, agentIds,
                     agentParams, threshold, 0)
             ).to.be.revertedWith("NOT_MINTED");
         });
@@ -347,12 +336,12 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
-            const service = await serviceRegistry.connect(serviceManager).update(owner, description, configHash,
+            const service = await serviceRegistry.connect(serviceManager).update(owner, configHash,
                 agentIds, agentParams, maxThreshold, 1);
             const result = await service.wait();
             expect(result.events[0].event).to.equal("UpdateService");
@@ -367,10 +356,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
 
@@ -381,7 +370,7 @@ describe("ServiceRegistry", function () {
 
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
             await expect(
-                serviceRegistry.connect(serviceManager).update(owner, description, configHash, agentIds,
+                serviceRegistry.connect(serviceManager).update(owner, configHash, agentIds,
                     agentParams, maxThreshold, 1)
             ).to.be.revertedWith("WrongServiceState");
         });
@@ -391,20 +380,20 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // If we update with the same config hash as previous one, it must not be added
-            await serviceRegistry.connect(serviceManager).update(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).update(owner, configHash, agentIds,
                 agentParams, maxThreshold, 1);
             let hashes = await serviceRegistry.getPreviousHashes(serviceId);
             expect(hashes.numHashes).to.equal(0);
 
             // Now we are going to have two config hashes
-            await serviceRegistry.connect(serviceManager).update(owner, description, configHash1, agentIds,
+            await serviceRegistry.connect(serviceManager).update(owner, configHash1, agentIds,
                 agentParams, maxThreshold, 1);
             hashes = await serviceRegistry.getPreviousHashes(serviceId);
             expect(hashes.numHashes).to.equal(1);
@@ -439,10 +428,10 @@ describe("ServiceRegistry", function () {
             const agentInstance = signers[7].address;
 
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await expect(
                 serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond})
@@ -456,10 +445,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
@@ -475,10 +464,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -494,10 +483,10 @@ describe("ServiceRegistry", function () {
             const agentInstances = [signers[7].address, signers[8].address, signers[9].address, signers[10].address];
             const regAgentIds = [agentId, agentId, agentId, agentId];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -512,10 +501,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             const regAgent = await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
@@ -531,12 +520,12 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = [signers[7].address, signers[8].address, signers[9].address];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId + 1, {value: regDeposit});
@@ -555,10 +544,10 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstances = [signers[7].address, signers[8].address];
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -589,10 +578,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await expect(
@@ -606,10 +595,10 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
 
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             const activateService = await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId,
                 {value: regDeposit});
@@ -622,10 +611,10 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             const terminateService = await serviceRegistry.connect(serviceManager).terminate(owner, serviceId);
@@ -643,10 +632,10 @@ describe("ServiceRegistry", function () {
 
             // Create agents and a service
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Activate registration and register and agent instance
@@ -680,11 +669,11 @@ describe("ServiceRegistry", function () {
             const operator = signers[6].address;
             const agentInstance = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, [agentInstance], [agentId], {value: regBond});
@@ -704,13 +693,13 @@ describe("ServiceRegistry", function () {
 
             // Create components
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, description, componentHash, []);
-            await componentRegistry.connect(mechManager).create(owner, description, componentHash1, [1]);
+            await componentRegistry.connect(mechManager).create(owner, componentHash, []);
+            await componentRegistry.connect(mechManager).create(owner, componentHash1, [1]);
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1, 2]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1, 2]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -719,7 +708,7 @@ describe("ServiceRegistry", function () {
             let serviceInstance = await serviceRegistry.getService(serviceId);
             expect(serviceInstance.state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1, 2],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1, 2],
                 [[2, regBond], [1, regBond]], maxThreshold);
             serviceInstance = await serviceRegistry.getService(serviceId);
             expect(serviceInstance.state).to.equal(1);
@@ -769,13 +758,13 @@ describe("ServiceRegistry", function () {
 
             // Create components
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(owner, description, componentHash, []);
-            await componentRegistry.connect(mechManager).create(owner, description, componentHash1, [1]);
+            await componentRegistry.connect(mechManager).create(owner, componentHash, []);
+            await componentRegistry.connect(mechManager).create(owner, componentHash1, [1]);
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1, 2]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1, 2]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -784,9 +773,9 @@ describe("ServiceRegistry", function () {
             let serviceInstance = await serviceRegistry.getService(serviceId);
             expect(serviceInstance.state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash1, [2],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash1, [2],
                 [[2, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
@@ -821,8 +810,8 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[2];
             const owner = signers[3].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
 
             // Initially owner does not have any services
             expect(await serviceRegistry.exists(serviceId)).to.equal(false);
@@ -830,7 +819,7 @@ describe("ServiceRegistry", function () {
 
             // Creating a service
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Initial checks
@@ -840,7 +829,6 @@ describe("ServiceRegistry", function () {
 
             // Check for the service info components
             const serviceInstance = await serviceRegistry.getService(serviceId);
-            expect(serviceInstance.description).to.equal(description);
             expect(serviceInstance.agentIds.length).to.equal(agentIds.length);
             expect(serviceInstance.configHash.hash).to.equal(configHash.hash);
             for (let i = 0; i < agentIds.length; i++) {
@@ -859,18 +847,18 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[2];
             const owner = signers[3].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash2, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash2, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Updating a service
             const newAgentIds = [1, 2, 3];
             const newAgentParams = [[2, regBond], [0, regBond], [1, regBond]];
             const newMaxThreshold = newAgentParams[0][0] + newAgentParams[2][0];
-            await serviceRegistry.connect(serviceManager).update(owner, description, configHash, newAgentIds,
+            await serviceRegistry.connect(serviceManager).update(owner, configHash, newAgentIds,
                 newAgentParams, newMaxThreshold, serviceId);
 
             // Initial checks
@@ -882,7 +870,6 @@ describe("ServiceRegistry", function () {
 
             // Check for the service info components
             const serviceInstance = await serviceRegistry.getService(serviceId);
-            expect(serviceInstance.description).to.equal(description);
             expect(serviceInstance.agentIds.length).to.equal(agentIds.length);
             const agentIdsCheck = [newAgentIds[0], newAgentIds[2]];
             for (let i = 0; i < agentIds.length; i++) {
@@ -899,7 +886,7 @@ describe("ServiceRegistry", function () {
             expect(agentInstancesInfo.numAgentInstances).to.equal(0);
 
             // Creating a second service and do basic checks
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIdsCheck,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIdsCheck,
                 agentNumSlotsCheck, newMaxThreshold);
             expect(await serviceRegistry.exists(serviceId + 1)).to.equal(true);
             expect(await serviceRegistry.balanceOf(owner)).to.equal(2);
@@ -922,9 +909,9 @@ describe("ServiceRegistry", function () {
             const regAgentIds = [agentId, agentId];
             const maxThreshold = 2;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
             await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId, agentInstances,
@@ -958,11 +945,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Terminating service without registered agent instances will give it a terminated-unbonded state
@@ -981,11 +968,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
@@ -1008,12 +995,12 @@ describe("ServiceRegistry", function () {
             const serviceManager = signers[4];
             const owner = signers[5].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
 
             // Creating the service
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, maxThreshold);
 
             // Activate registration and terminate right after
@@ -1034,11 +1021,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Revert when insufficient amount is passed
@@ -1091,11 +1078,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and try to unbond
@@ -1117,11 +1104,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
@@ -1140,11 +1127,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agent
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             // Activate registration and register one agent instance
@@ -1163,11 +1150,11 @@ describe("ServiceRegistry", function () {
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create a service and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[1, regBond]], 1);
 
             // Activate registration and register an agent instance
@@ -1207,7 +1194,7 @@ describe("ServiceRegistry", function () {
 
             // Create agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Whitelist gnosis multisig implementation
             await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -1216,7 +1203,7 @@ describe("ServiceRegistry", function () {
             let serviceInstance = await serviceRegistry.getService(serviceId);
             expect(serviceInstance.state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[1, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
@@ -1265,13 +1252,13 @@ describe("ServiceRegistry", function () {
 
             // Create an agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
 
             // Create services and activate the agent instance registration
             let serviceInstance = await serviceRegistry.getService(serviceId);
             expect(serviceInstance.state).to.equal(0);
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[2, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner, serviceId, {value: regDeposit});
@@ -1343,16 +1330,16 @@ describe("ServiceRegistry", function () {
             const owner = signers[5].address;
             const operator = signers[6].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             // Create a service
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash,
                 agentIds, agentParams, maxThreshold);
 
             // Trying to update with a wrong manager
             await expect(
-                serviceRegistry.update(owner, description, configHash, agentIds, agentParams, threshold, serviceId)
+                serviceRegistry.update(owner, configHash, agentIds, agentParams, threshold, serviceId)
             ).to.be.revertedWith("ManagerOnly");
 
             // Trying to activate the service with a wrong manager
@@ -1388,16 +1375,16 @@ describe("ServiceRegistry", function () {
             const nonOwner = signers[6].address;
             const operator = signers[7].address;
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash, [1]);
-            await agentRegistry.connect(mechManager).create(owner, description, agentHash1, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash, [1]);
+            await agentRegistry.connect(mechManager).create(owner, agentHash1, [1]);
             await serviceRegistry.changeManager(serviceManager.address);
             // Create a service
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash,
                 agentIds, agentParams, maxThreshold);
 
             // Trying to update with a wrong manager
             await expect(
-                serviceRegistry.connect(serviceManager).update(nonOwner, description, configHash, agentIds, agentParams,
+                serviceRegistry.connect(serviceManager).update(nonOwner, configHash, agentIds, agentParams,
                     threshold, serviceId)
             ).to.be.revertedWith("OwnerOnly");
 
@@ -1464,22 +1451,22 @@ describe("ServiceRegistry", function () {
 
             // Create 4 components (one is already created in the beforeEach()) and 3 agents based on them
             await componentRegistry.changeManager(mechManager.address);
-            await componentRegistry.connect(mechManager).create(componentOwners[0].address, description, componentHash, []);
-            await componentRegistry.connect(mechManager).create(componentOwners[1].address, description, componentHash1, []);
-            await componentRegistry.connect(mechManager).create(componentOwners[2].address, description, componentHash2, []);
+            await componentRegistry.connect(mechManager).create(componentOwners[0].address, componentHash, []);
+            await componentRegistry.connect(mechManager).create(componentOwners[1].address, componentHash1, []);
+            await componentRegistry.connect(mechManager).create(componentOwners[2].address, componentHash2, []);
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.connect(mechManager).create(agentOwners[0].address, description, agentHash, [1, 2]);
-            await agentRegistry.connect(mechManager).create(agentOwners[1].address, description, agentHash1, [2]);
-            await agentRegistry.connect(mechManager).create(agentOwners[2].address, description, agentHash2, [3]);
+            await agentRegistry.connect(mechManager).create(agentOwners[0].address, agentHash, [1, 2]);
+            await agentRegistry.connect(mechManager).create(agentOwners[1].address, agentHash1, [2]);
+            await agentRegistry.connect(mechManager).create(agentOwners[2].address, agentHash2, [3]);
 
             // Create 2 services
             const agentIds = [[1, 2], [1, 3]];
             const agentParams = [[1, regBond], [1, regBond]];
             const threshold = 2;
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds[0],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds[0],
                 agentParams, threshold);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash1, agentIds[1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash1, agentIds[1],
                 agentParams, threshold);
 
             // Register agent instances
@@ -1521,60 +1508,60 @@ describe("ServiceRegistry", function () {
             // Create 10 components (one is already created in the beforeEach()) and 3 agents based on them
             await componentRegistry.changeManager(mechManager.address);
             // c2
-            await componentRegistry.create(owner, description, hash, [1]);
+            await componentRegistry.create(owner, hash, [1]);
             // c3
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [1, 2]);
+            await componentRegistry.create(owner, hash, [1, 2]);
             // c4
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [1, 3]);
+            await componentRegistry.create(owner, hash, [1, 3]);
             // c5
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [1, 3, 4]);
+            await componentRegistry.create(owner, hash, [1, 3, 4]);
             // c6
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [2, 4, 5]);
+            await componentRegistry.create(owner, hash, [2, 4, 5]);
             // c7
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, []);
+            await componentRegistry.create(owner, hash, []);
             // c8
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [4]);
+            await componentRegistry.create(owner, hash, [4]);
             // c9
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3, 4, 6]);
+            await componentRegistry.create(owner, hash, [3, 4, 6]);
             // c10
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [6, 8, 9]);
+            await componentRegistry.create(owner, hash, [6, 8, 9]);
 
             await agentRegistry.changeManager(mechManager.address);
             // a1
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await agentRegistry.create(owner, description, hash, [5, 6]);
+            await agentRegistry.create(owner, hash, [5, 6]);
             // a2
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await agentRegistry.create(owner, description, hash, [5, 9]);
+            await agentRegistry.create(owner, hash, [5, 9]);
             // a3
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await agentRegistry.create(owner, description, hash, [6, 9, 10]);
+            await agentRegistry.create(owner, hash, [6, 9, 10]);
 
             // Create 1 service consisting of all three agents
             const agentIds = [1, 2, 3];
             const agentParams = [[1, regBond], [1, regBond], [1, regBond]];
             const threshold = 3;
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, agentIds,
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, agentIds,
                 agentParams, threshold);
 
             // Register agent instances
@@ -1629,57 +1616,57 @@ describe("ServiceRegistry", function () {
             // Create 11 components (one is already created in the beforeEach()) and 3 agents based on them
             await componentRegistry.changeManager(mechManager.address);
             // c2
-            await componentRegistry.create(owner, description, hash, []);
+            await componentRegistry.create(owner, hash, []);
             // c3
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [1]);
+            await componentRegistry.create(owner, hash, [1]);
             // c4
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [2, 3]);
+            await componentRegistry.create(owner, hash, [2, 3]);
             // c5
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3]);
+            await componentRegistry.create(owner, hash, [3]);
             // c6
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3]);
+            await componentRegistry.create(owner, hash, [3]);
             // c7
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3]);
+            await componentRegistry.create(owner, hash, [3]);
             // c8
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3]);
+            await componentRegistry.create(owner, hash, [3]);
             // c9
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3]);
+            await componentRegistry.create(owner, hash, [3]);
             // c10
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [3]);
+            await componentRegistry.create(owner, hash, [3]);
             // c11
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await componentRegistry.create(owner, description, hash, [2, 3, 6, 7, 8, 9, 10]);
+            await componentRegistry.create(owner, hash, [2, 3, 6, 7, 8, 9, 10]);
 
             await agentRegistry.changeManager(mechManager.address);
             // a1
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await agentRegistry.create(owner, description, hash, [4]);
+            await agentRegistry.create(owner, hash, [4]);
             // a2
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await agentRegistry.create(owner, description, hash, [5]);
+            await agentRegistry.create(owner, hash, [5]);
             // a3
             salt += "00";
             hash = ethers.utils.keccak256(salt);
-            await agentRegistry.create(owner, description, hash, [11]);
+            await agentRegistry.create(owner, hash, [11]);
 
             // Create 3 services consisting of one agent each
             const agentIds = [1, 2, 3];
@@ -1687,7 +1674,7 @@ describe("ServiceRegistry", function () {
             const threshold = 1;
             await serviceRegistry.changeManager(serviceManager.address);
             for (let i = 0; i < 3; i++) {
-                await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [agentIds[i]],
+                await serviceRegistry.connect(serviceManager).create(owner, configHash, [agentIds[i]],
                     [agentParams[i]], threshold);
             }
 
@@ -1749,8 +1736,8 @@ describe("ServiceRegistry", function () {
 
             // Create two agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.create(owner, description, agentHash, [1]);
-            await agentRegistry.create(owner, description, agentHash1, [1]);
+            await agentRegistry.create(owner, agentHash, [1]);
+            await agentRegistry.create(owner, agentHash1, [1]);
 
             // Change the manager to the attacker contract address
             await serviceRegistry.changeManager(reentrancyAttacker.address);
@@ -1758,7 +1745,7 @@ describe("ServiceRegistry", function () {
             // Simulate the reentrancy attack
             await reentrancyAttacker.setAttackOnCreate(true);
             await expect(
-                reentrancyAttacker.createBadService(reentrancyAttacker.address, description, configHash, agentIds,
+                reentrancyAttacker.createBadService(reentrancyAttacker.address, configHash, agentIds,
                     agentParams, maxThreshold)
             ).to.be.revertedWith("ReentrancyGuard");
         });
@@ -1773,11 +1760,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.create(owner, description, agentHash, [1]);
+            await agentRegistry.create(owner, agentHash, [1]);
 
             // Create services and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(reentrancyAttacker.address, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(reentrancyAttacker.address, configHash, [1],
                 [[1, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(reentrancyAttacker.address,
@@ -1808,11 +1795,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.create(owner, description, agentHash, [1]);
+            await agentRegistry.create(owner, agentHash, [1]);
 
             // Create services and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(reentrancyAttacker.address, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(reentrancyAttacker.address, configHash, [1],
                 [[1, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(reentrancyAttacker.address,
@@ -1844,11 +1831,11 @@ describe("ServiceRegistry", function () {
 
             // Create an agents
             await agentRegistry.changeManager(mechManager.address);
-            await agentRegistry.create(owner, description, agentHash, [1]);
+            await agentRegistry.create(owner, agentHash, [1]);
 
             // Create services and activate the agent instance registration
             await serviceRegistry.changeManager(serviceManager.address);
-            await serviceRegistry.connect(serviceManager).create(owner, description, configHash, [1],
+            await serviceRegistry.connect(serviceManager).create(owner, configHash, [1],
                 [[1, regBond]], maxThreshold);
 
             await serviceRegistry.connect(serviceManager).activateRegistration(owner,


### PR DESCRIPTION
- Removing description from all the units as it can be taken from the metadata;
- Removing the check for duplicate hashes, since it's easy to pack exactly the same metadata into a different hash, so that check does not prove that the same data is not used;
- Updating tests.