### PR TITLE
chore: switching from MultiSend to MultiSendCallOnly

### DIFF
--- a/contracts/test/GnosisSafeABICreator.sol
+++ b/contracts/test/GnosisSafeABICreator.sol
@@ -4,4 +4,4 @@ pragma solidity ^0.8.15;
 // Getting ABIs for the Gnosis Safe master copy and proxy contracts
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
-import "@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol";
+import "@gnosis.pm/safe-contracts/contracts/libraries/MultiSendCallOnly.sol";

--- a/deploy/contracts.js
+++ b/deploy/contracts.js
@@ -96,14 +96,21 @@ module.exports = async () => {
     const gnosisSafeSameAddressMultisig = await GnosisSafeSameAddressMultisig.deploy();
     await gnosisSafeSameAddressMultisig.deployed();
 
+    const MultiSend = await ethers.getContractFactory("MultiSendCallOnly");
+    const multiSend = await MultiSend.deploy();
+    await multiSend.deployed();
+
     console.log("==========================================");
     console.log("ComponentRegistry deployed to:", componentRegistry.address);
     console.log("AgentRegistry deployed to:", agentRegistry.address);
     console.log("RegistriesManager deployed to:", registriesManager.address);
     console.log("ServiceRegistry deployed to:", serviceRegistry.address);
     console.log("ServiceManager deployed to:", serviceManager.address);
+    console.log("Gnosis Safe master copy deployed to:", gnosisSafe.address);
+    console.log("Gnosis Safe proxy factory deployed to:", gnosisSafeProxyFactory.address);
     console.log("Gnosis Safe Multisig deployed to:", gnosisSafeMultisig.address);
     console.log("Gnosis Safe Multisig with same address deployed to:", gnosisSafeSameAddressMultisig.address);
+    console.log("Gnosis Safe Multisend deployed to:", multiSend.address);
 
     // Whitelist gnosis multisig implementations
     await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
@@ -239,8 +246,11 @@ module.exports = async () => {
         "registriesManager": registriesManager.address,
         "serviceRegistry": serviceRegistry.address,
         "serviceManager": serviceManager.address,
+        "gnosisSafe": gnosisSafe.address,
+        "gnosisSafeProxyFactory": gnosisSafeProxyFactory.address,
         "Multisig implementation": gnosisSafeMultisig.address,
         "Multisig implementation with same address": gnosisSafeSameAddressMultisig.address,
+        "multiSend": multiSend.address,
         "operator": {
             "address": operator.address,
             "privateKey": operatorPK

--- a/test/GnosisSafeSameAddressMultisig.js
+++ b/test/GnosisSafeSameAddressMultisig.js
@@ -25,7 +25,7 @@ describe("GnosisSafeSameAddressMultisig", function () {
         gnosisSafeProxyFactory = await GnosisSafeProxyFactory.deploy();
         await gnosisSafeProxyFactory.deployed();
 
-        const MultiSend = await ethers.getContractFactory("MultiSend");
+        const MultiSend = await ethers.getContractFactory("MultiSendCallOnly");
         multiSend = await MultiSend.deploy();
         await multiSend.deployed();
 

--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -61,7 +61,7 @@ describe("ServiceRegistry", function () {
         gnosisSafeMultisig = await GnosisSafeMultisig.deploy(gnosisSafe.address, gnosisSafeProxyFactory.address);
         await gnosisSafeMultisig.deployed();
 
-        const MultiSend = await ethers.getContractFactory("MultiSend");
+        const MultiSend = await ethers.getContractFactory("MultiSendCallOnly");
         multiSend = await MultiSend.deploy();
         await multiSend.deployed();
 


### PR DESCRIPTION
- `MultiSend` checks for the call not being originated by the master copy, whereas `MultiSendCallOnly` does not track nested delegate calls;
- The behavior in the test environment of `MultiSend` with our requirements and tests is somehow equal to the `MultiSendCallOnly` one, however on the mainnet all the checks for the master copy for delegatecalls are strict.