### PR TITLE
test: redeploy a service with the same multisig owned by a multisig

### DIFF
--- a/contracts/test/GnosisSafeABICreator.sol
+++ b/contracts/test/GnosisSafeABICreator.sol
@@ -5,3 +5,5 @@ pragma solidity ^0.8.15;
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
 import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
 import "@gnosis.pm/safe-contracts/contracts/libraries/MultiSendCallOnly.sol";
+import "@gnosis.pm/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";
+import "@gnosis.pm/safe-contracts/contracts/examples/libraries/SignMessage.sol";

--- a/contracts/test/GnosisSafeABICreator.sol
+++ b/contracts/test/GnosisSafeABICreator.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.15;
 
 // Getting ABIs for the Gnosis Safe master copy and proxy contracts
 import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+import "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
 import "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
 import "@gnosis.pm/safe-contracts/contracts/libraries/MultiSendCallOnly.sol";
-import "@gnosis.pm/safe-contracts/contracts/handler/CompatibilityFallbackHandler.sol";
-import "@gnosis.pm/safe-contracts/contracts/examples/libraries/SignMessage.sol";

--- a/scripts/deployment/deploy_06_gnosis_safe_multisig.js
+++ b/scripts/deployment/deploy_06_gnosis_safe_multisig.js
@@ -11,8 +11,6 @@ async function main() {
     const useLedger = parsedData.useLedger;
     const derivationPath = parsedData.derivationPath;
     const providerName = parsedData.providerName;
-    const gnosisSafeAddress = parsedData.gnosisSafeAddress;
-    const gnosisSafeProxyFactoryAddress = parsedData.gnosisSafeProxyFactoryAddress;
     let EOA;
 
     const provider = await ethers.providers.getDefaultProvider(providerName);

--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -10,7 +10,10 @@ describe("ServiceRegistry", function () {
     let gnosisSafe;
     let serviceRegistryL2;
     let gnosisSafeMultisig;
+    let gnosisSafeProxyFactory;
+    let compatibilityFallbackHandler;
     let multiSend;
+    let signMessageLib;
     let gnosisSafeSameAddressMultisig;
     let reentrancyAttacker;
     let reentrancyAttackerL2;
@@ -54,16 +57,24 @@ describe("ServiceRegistry", function () {
         await gnosisSafe.deployed();
 
         const GnosisSafeProxyFactory = await ethers.getContractFactory("GnosisSafeProxyFactory");
-        const gnosisSafeProxyFactory = await GnosisSafeProxyFactory.deploy();
+        gnosisSafeProxyFactory = await GnosisSafeProxyFactory.deploy();
         await gnosisSafeProxyFactory.deployed();
 
         const GnosisSafeMultisig = await ethers.getContractFactory("GnosisSafeMultisig");
         gnosisSafeMultisig = await GnosisSafeMultisig.deploy(gnosisSafe.address, gnosisSafeProxyFactory.address);
         await gnosisSafeMultisig.deployed();
 
+        const CompatibilityFallbackHandler = await ethers.getContractFactory("CompatibilityFallbackHandler");
+        compatibilityFallbackHandler = await CompatibilityFallbackHandler.deploy();
+        await compatibilityFallbackHandler.deployed();
+
         const MultiSend = await ethers.getContractFactory("MultiSendCallOnly");
         multiSend = await MultiSend.deploy();
         await multiSend.deployed();
+
+        const SignMessageLib = await ethers.getContractFactory("SignMessageLib");
+        signMessageLib = await SignMessageLib.deploy();
+        await signMessageLib.deployed();
 
         const GnosisSafeSameAddressMultisig = await ethers.getContractFactory("GnosisSafeSameAddressMultisig");
         gnosisSafeSameAddressMultisig = await GnosisSafeSameAddressMultisig.deploy();
@@ -1415,6 +1426,166 @@ describe("ServiceRegistry", function () {
                 // Check that the service is deployed
                 const service = await serviceRegistry.getService(serviceId);
                 expect(service.state).to.equal(4);
+            });
+
+            it("Changing multisig for its re-deployment in a service via multisend with the multisig owner", async function () {
+                if (serviceRegistryImplementation == "l2") {
+                    serviceRegistry = serviceRegistryL2;
+                }
+
+                const mechManager = signers[3];
+                const serviceManager = signers[4];
+                const operator = signers[6].address;
+                const agentInstances = [signers[7], signers[8], signers[9], signers[10]];
+                const maxThreshold = 1;
+                const newMaxThreshold = 4;
+                const serviceOwnerOwners = [signers[11], signers[12], signers[13]];
+                const serviceOwnerOwnersAddresses = [signers[11].address, signers[12].address, signers[13].address];
+                const serviceOwnerThreshold = 2;
+
+                // Create a multisig that will be the service owner
+                const safeContracts = require("@gnosis.pm/safe-contracts");
+                const setupData = gnosisSafe.interface.encodeFunctionData(
+                    "setup",
+                    // signers, threshold, to_address, data, fallback_handler, payment_token, payment, payment_receiver
+                    [serviceOwnerOwnersAddresses, serviceOwnerThreshold, AddressZero, "0x",
+                        compatibilityFallbackHandler.address, AddressZero, 0, AddressZero]
+                );
+                let proxyAddress = await safeContracts.calculateProxyAddress(gnosisSafeProxyFactory, gnosisSafe.address,
+                    setupData, 0);
+                await gnosisSafeProxyFactory.createProxyWithNonce(gnosisSafe.address, setupData, 0).then((tx) => tx.wait());
+                const serviceOwnerMultisig = await ethers.getContractAt("GnosisSafe", proxyAddress);
+                const serviceOwnerAddress = serviceOwnerMultisig.address;
+
+                if (serviceRegistryImplementation == "l1") {
+                    // Create an agent
+                    await agentRegistry.changeManager(mechManager.address);
+                    await agentRegistry.connect(mechManager).create(signers[0].address, agentHash, [1]);
+                }
+
+                // Create services and activate the agent instance registration
+                await serviceRegistry.changeManager(serviceManager.address);
+                await serviceRegistry.connect(serviceManager).create(serviceOwnerAddress, configHash, [1],
+                    [[1, regBond]], maxThreshold);
+
+                // Activate agent instance registration
+                await serviceRegistry.connect(serviceManager).activateRegistration(serviceOwnerAddress, serviceId, {value: regDeposit});
+
+                /// Register agent instance
+                await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
+                    [agentInstances[0].address], [agentId], {value: regBond});
+
+                // Whitelist both gnosis multisig implementations
+                await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
+                await serviceRegistry.changeMultisigPermission(gnosisSafeSameAddressMultisig.address, true);
+
+                // Deploy the service and create a multisig and get its address
+                const safe = await serviceRegistry.connect(serviceManager).deploy(serviceOwnerAddress, serviceId,
+                    gnosisSafeMultisig.address, payload);
+                const result = await safe.wait();
+                proxyAddress = result.events[0].address;
+                // Getting a real multisig address
+                const multisig = await ethers.getContractAt("GnosisSafe", proxyAddress);
+
+                // Terminate a service after some time since there's a need to add agent instances
+                await serviceRegistry.connect(serviceManager).terminate(serviceOwnerAddress, serviceId);
+
+                // Unbond the agent instance in order to update the service
+                await serviceRegistry.connect(serviceManager).unbond(operator, serviceId);
+
+                // At this point of time the agent instance gives the ownership rights to the service owner
+                // In other words, swap the owner of the multisig to the service owner (agent instance to give up rights for the service owner)
+                // Since there was only one agent instance, the previous multisig owner address is the sentinel one defined by gnosis (0x1)
+                const sentinelOwners = "0x" + "0".repeat(39) + "1";
+                let nonce = await multisig.nonce();
+                let txHashData = await safeContracts.buildContractCall(multisig, "swapOwner",
+                    [sentinelOwners, agentInstances[0].address, serviceOwnerAddress], nonce, 0, 0);
+                let signMessageData = await safeContracts.safeSignMessage(agentInstances[0], multisig, txHashData, 0);
+                await safeContracts.executeTx(multisig, txHashData, [signMessageData], 0);
+
+                // Updating a service
+                await serviceRegistry.connect(serviceManager).update(serviceOwnerAddress, configHash, [1], [[4, regBond]],
+                    newMaxThreshold, serviceId);
+
+                // Activate agent instance registration
+                await serviceRegistry.connect(serviceManager).activateRegistration(serviceOwnerAddress, serviceId, {value: regDeposit});
+
+                /// Register agent instance
+                await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
+                    [agentInstances[0].address, agentInstances[1].address, agentInstances[2].address, agentInstances[3].address],
+                    [agentId, agentId, agentId, agentId], {value: 4 * regBond});
+
+                // Change the existent multisig owners and threshold in a multisend transaction using the service owner access
+                let callData = [];
+                let txs = [];
+                nonce = await multisig.nonce();
+                // Add the addresses, but keep the threshold the same
+                for (let i = 0; i < agentInstances.length; i++) {
+                    callData[i] = multisig.interface.encodeFunctionData("addOwnerWithThreshold", [agentInstances[i].address, 1]);
+                    txs[i] = safeContracts.buildSafeTransaction({to: multisig.address, data: callData[i], nonce: 0});
+                }
+                // Remove the original multisig owner and change the threshold
+                // Note that the prevOwner is the very first added address as it corresponds to the reverse order of added addresses
+                // The order in the gnosis safe multisig is as follows: sentinelOwners => agentInstances[last].address => ... =>
+                // => newOwnerAddresses[0].address => serviceOwnerAddress
+                callData.push(multisig.interface.encodeFunctionData("removeOwner", [agentInstances[0].address, serviceOwnerAddress,
+                    newMaxThreshold]));
+                txs.push(safeContracts.buildSafeTransaction({to: multisig.address, data: callData[callData.length - 1], nonce: 0}));
+
+                // Build a multisend transaction to be executed by the multisig
+                const safeTx = safeContracts.buildMultiSendSafeTx(multiSend, txs, nonce);
+
+                // Create a message data from the multisend transaction
+                const messageData = await multisig.encodeTransactionData(safeTx.to, safeTx.value, safeTx.data,
+                    safeTx.operation, safeTx.safeTxGas, safeTx.baseGas, safeTx.gasPrice, safeTx.gasToken,
+                    safeTx.refundReceiver, nonce);
+
+                // Sign multisend message for the service owner multisig
+                await safeContracts.executeContractCallWithSigners(serviceOwnerMultisig, signMessageLib, "signMessage",
+                    [messageData], [serviceOwnerOwners[0], serviceOwnerOwners[1]], true);
+                // on the front-end something like: await signMessageLib.connect(serviceOwnerMultisig).signMessage(messageData);
+
+                // Get the signature line
+                // Inspired by: https://github.com/safe-global/safe-contracts/pull/416/files
+                // 12 bytes of padding + 20 bytes of address + 32 bytes of s + 1 byte of v
+                const signatureLength = 65;
+                // Calculate the s part length in hex with leading zeros padding to be 32 bytes in total
+                const sPartPadded64 = (serviceOwnerThreshold * signatureLength).toString(16).padStart(64, "0"); // 65 in hex is 0x41
+                const staticPart = "0x000000000000000000000000" + serviceOwnerAddress.slice(2) + sPartPadded64 + "00"; // r, s, v
+                // Dynamic part consists of zero bytes of length equal to 65 bytes * threshold - first 65 initial ones + 32
+                const dynamicPart = "00".repeat(signatureLength * (serviceOwnerThreshold - 1) + 32);
+                const signatureBytes = staticPart + dynamicPart;
+
+                const safeExecData = gnosisSafe.interface.encodeFunctionData("execTransaction", [safeTx.to, safeTx.value,
+                    safeTx.data, safeTx.operation, safeTx.safeTxGas, safeTx.baseGas, safeTx.gasPrice, safeTx.gasToken,
+                    safeTx.refundReceiver, signatureBytes]);
+
+                // Add the multisig address on top of the multisig exec transaction data
+                const packedData = ethers.utils.solidityPack(["address", "bytes"], [multisig.address, safeExecData]);
+
+                // Redeploy the service updating the multisig with new owners and threshold
+                await serviceRegistry.connect(serviceManager).deploy(serviceOwnerAddress, serviceId,
+                    gnosisSafeSameAddressMultisig.address, packedData);
+
+                // Check that the service is deployed
+                const service = await serviceRegistry.getService(serviceId);
+                expect(service.state).to.equal(4);
+
+                ///////////////////////////////////////// TO CONSIDER LATER
+                //                // Build multisend message data
+                //                const messageData = ethers.utils.solidityPack(["address", "uint256", "bytes", "uint8", "uint256", "uint256", "uint256", "uint256", "uint256", "uint256"],
+                //                    [safeTx.to, safeTx.value, safeTx.data, safeTx.operation, safeTx.safeTxGas, safeTx.baseGas, safeTx.gasPrice, safeTx.gasToken, safeTx.refundReceiver, nonce]);
+                //
+                //                // Sign multisend message via a signMessageLib
+                //                nonce = await serviceOwnerMultisig.nonce();
+                //                txHashData = await safeContracts.buildContractCall(signMessageLib, "signMessage",
+                //                    [messageData], nonce, 1, 0);
+                //                signMessageData = [await safeContracts.safeSignMessage(serviceOwnerOwners[0], serviceOwnerMultisig, txHashData, 0),
+                //                    await safeContracts.safeSignMessage(serviceOwnerOwners[1], serviceOwnerMultisig, txHashData, 0)];
+                //
+                //                // on the front-end: await signMessageLib.connect(serviceOwnerMultisig).signMessage(messageData);
+                //                await safeContracts.executeTx(serviceOwnerMultisig, txHashData, signMessageData, 0);
+                ////////////////////////////////////////////
             });
         });
     });


### PR DESCRIPTION
- Simulating redeployment of a service with the same multisig (parent multisig) owned by the service owner multisig (child multisig);
- Data location inheritance bug in the Safe interface: https://blog.soliditylang.org/2022/05/17/data-location-inheritance-bug/
- Use `DefaultCallbackHandler` instead of the `CompatibilityFallbackHandler` for the service owner multisig to avoid manual patching of gnosis safe files, and yet to have the ERC721 support.