### PR TITLE
test: adding a test with the swap when changing multisig owners

### DIFF
--- a/test/ServiceRegistry.js
+++ b/test/ServiceRegistry.js
@@ -1569,6 +1569,163 @@ describe("ServiceRegistry", function () {
                 expect(service.state).to.equal(4);
             });
 
+            it("Changing multisig for its re-deployment in a service via multisend on a smart contract side using the swapOwner function", async function () {
+                if (serviceRegistryImplementation == "l2") {
+                    serviceRegistry = serviceRegistryL2;
+                }
+                if (serviceRegistryImplementation == "l1an") {
+                    serviceRegistry = serviceRegistryAnnotated;
+                }
+
+                const mechManager = signers[3];
+                const serviceManager = signers[4];
+                const serviceOwner = signers[5];
+                const serviceOwnerAddress = signers[5].address;
+                const operator = signers[6].address;
+                const agentInstances = [signers[7], signers[8], signers[9], signers[10]];
+                const maxThreshold = 1;
+                const newMaxThreshold = 4;
+
+                if (serviceRegistryImplementation == "l1" || serviceRegistryImplementation == "l1an") {
+                    // Create an agent
+                    await agentRegistry.changeManager(mechManager.address);
+                    await agentRegistry.connect(mechManager).create(serviceOwnerAddress, agentHash, [1]);
+                }
+
+                // Create services and activate the agent instance registration
+                await serviceRegistry.changeManager(serviceManager.address);
+                await serviceRegistry.connect(serviceManager).create(serviceOwnerAddress, configHash, [1],
+                    [[1, regBond]], maxThreshold);
+
+                // Activate agent instance registration
+                await serviceRegistry.connect(serviceManager).activateRegistration(serviceOwnerAddress, serviceId, {value: regDeposit});
+
+                /// Register agent instance
+                await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
+                    [agentInstances[0].address], [agentId], {value: regBond});
+
+                // Whitelist both gnosis multisig implementations
+                await serviceRegistry.changeMultisigPermission(gnosisSafeMultisig.address, true);
+                await serviceRegistry.changeMultisigPermission(gnosisSafeSameAddressMultisig.address, true);
+
+                // Deploy the service and create a multisig and get its address
+                const safe = await serviceRegistry.connect(serviceManager).deploy(serviceOwnerAddress, serviceId,
+                    gnosisSafeMultisig.address, payload);
+                const result = await safe.wait();
+                const proxyAddress = result.events[0].address;
+                // Getting a real multisig address
+                const multisig = await ethers.getContractAt("GnosisSafe", proxyAddress);
+
+                // Terminate a service after some time since there's a need to add agent instances
+                await serviceRegistry.connect(serviceManager).terminate(serviceOwnerAddress, serviceId);
+
+                // Unbond the agent instance in order to update the service
+                await serviceRegistry.connect(serviceManager).unbond(operator, serviceId);
+
+                const safeContracts = require("@gnosis.pm/safe-contracts");
+                // At this point of time the agent instance gives the ownership rights to the service owner
+                // In other words, swap the owner of the multisig to the service owner (agent instance to give up rights for the service owner)
+                // Since there was only one agent instance, the previous multisig owner address is the sentinel one defined by gnosis (0x1)
+                const sentinelOwners = "0x" + "0".repeat(39) + "1";
+                let nonce = await multisig.nonce();
+                const txHashData = await safeContracts.buildContractCall(multisig, "swapOwner",
+                    [sentinelOwners, agentInstances[0].address, serviceOwnerAddress], nonce, 0, 0);
+                const signMessageData = await safeContracts.safeSignMessage(agentInstances[0], multisig, txHashData, 0);
+                await safeContracts.executeTx(multisig, txHashData, [signMessageData], 0);
+
+                // Updating a service
+                await serviceRegistry.connect(serviceManager).update(serviceOwnerAddress, configHash, [1], [[4, regBond]],
+                    newMaxThreshold, serviceId);
+
+                // Activate agent instance registration
+                await serviceRegistry.connect(serviceManager).activateRegistration(serviceOwnerAddress, serviceId, {value: regDeposit});
+
+                /// Register agent instance
+                await serviceRegistry.connect(serviceManager).registerAgents(operator, serviceId,
+                    [agentInstances[0].address, agentInstances[1].address, agentInstances[2].address, agentInstances[3].address],
+                    [agentId, agentId, agentId, agentId], {value: 4 * regBond});
+
+                // Change the existent multisig owners and threshold in a multisend transaction using the service owner access
+                let callData = [];
+                let txs = [];
+                nonce = await multisig.nonce();
+                // Add the addresses skipping the first one, but keep the threshold the same
+                for (let i = 0; i < agentInstances.length - 1; i++) {
+                    callData[i] = multisig.interface.encodeFunctionData("addOwnerWithThreshold", [agentInstances[i+1].address, 1]);
+                    txs[i] = safeContracts.buildSafeTransaction({to: multisig.address, data: callData[i], nonce: 0});
+                }
+                // Swap the original multisig owner with the first provided agent instance, and change the threshold separately
+                // Note that the prevOwner is the very first added address as it corresponds to the reverse order of added addresses
+                // The order in the gnosis safe multisig is as follows: sentinelOwners => agentInstances[last].address => ... =>
+                // => newOwnerAddresses[1].address => serviceOwnerAddress
+                // If changing just one owner to another, then instead of newOwnerAddresses[1].address we need sentinelOwners address
+                callData.push(multisig.interface.encodeFunctionData("swapOwner", [agentInstances[1].address, serviceOwnerAddress, agentInstances[0].address]));
+                txs.push(safeContracts.buildSafeTransaction({to: multisig.address, data: callData[callData.length - 1], nonce: 0}));
+                // Change threshold
+                callData.push(multisig.interface.encodeFunctionData("changeThreshold", [newMaxThreshold]));
+                txs.push(safeContracts.buildSafeTransaction({to: multisig.address, data: callData[callData.length - 1], nonce: 0}));
+
+                // Build a multisend transaction to be executed by the multisig
+                const safeTx = safeContracts.buildMultiSendSafeTx(multiSend, txs, nonce);
+                const chainId = (await ethers.provider.getNetwork()).chainId;
+                const EIP712_SAFE_TX_TYPE = {
+                    // "SafeTx(address to,uint256 value,bytes data,uint8 operation,uint256 safeTxGas,uint256 baseGas,uint256 gasPrice,address gasToken,address refundReceiver,uint256 nonce)"
+                    SafeTx: [
+                        { type: "address", name: "to" },
+                        { type: "uint256", name: "value" },
+                        { type: "bytes", name: "data" },
+                        { type: "uint8", name: "operation" },
+                        { type: "uint256", name: "safeTxGas" },
+                        { type: "uint256", name: "baseGas" },
+                        { type: "uint256", name: "gasPrice" },
+                        { type: "address", name: "gasToken" },
+                        { type: "address", name: "refundReceiver" },
+                        { type: "uint256", name: "nonce" },
+                    ]
+                };
+
+                // Get the signature of a multisend transaction
+                const signatureBytes = await serviceOwner._signTypedData({verifyingContract: multisig.address, chainId: chainId}, EIP712_SAFE_TX_TYPE, safeTx);
+
+                // Forming Gnosis Safe transaction bytes data: the multisig address itself plus the execTransaction() data
+                // that forms the multisend data with the signature bytes to be executed by the multisig proxy
+                const safeExecData = gnosisSafe.interface.encodeFunctionData("execTransaction", [safeTx.to, safeTx.value,
+                    safeTx.data, safeTx.operation, safeTx.safeTxGas, safeTx.baseGas, safeTx.gasPrice, safeTx.gasToken,
+                    safeTx.refundReceiver, signatureBytes]);
+
+                // Add the multisig address on top of the multisig exec transaction data
+                const packedData = ethers.utils.solidityPack(["address", "bytes"], [multisig.address, safeExecData]);
+
+                // Try to deploy when passing the incorrect payload of a multisend
+                let safeExecErrData = gnosisSafe.interface.encodeFunctionData("execTransaction", [safeTx.to, safeTx.value,
+                    "0xabcd", safeTx.operation, safeTx.safeTxGas, safeTx.baseGas, safeTx.gasPrice, safeTx.gasToken,
+                    safeTx.refundReceiver, signatureBytes]);
+                let packedErrData = ethers.utils.solidityPack(["address", "bytes"], [multisig.address, safeExecErrData]);
+                await expect(
+                    serviceRegistry.connect(serviceManager).deploy(serviceOwnerAddress, serviceId,
+                        gnosisSafeSameAddressMultisig.address, packedErrData)
+                ).to.be.revertedWithCustomError(gnosisSafeSameAddressMultisig, "MultisigExecFailed");
+
+                // Try to deploy when passing the incorrect tx signature
+                safeExecErrData = gnosisSafe.interface.encodeFunctionData("execTransaction", [safeTx.to, safeTx.value,
+                    safeTx.data, safeTx.operation, safeTx.safeTxGas, safeTx.baseGas, safeTx.gasPrice, safeTx.gasToken,
+                    safeTx.refundReceiver, "0xabcd"]);
+                packedErrData = ethers.utils.solidityPack(["address", "bytes"], [multisig.address, safeExecErrData]);
+                await expect(
+                    serviceRegistry.connect(serviceManager).deploy(serviceOwnerAddress, serviceId,
+                        gnosisSafeSameAddressMultisig.address, packedErrData)
+                ).to.be.revertedWithCustomError(gnosisSafeSameAddressMultisig, "MultisigExecFailed");
+
+
+                // Redeploy the service updating the multisig with new owners and threshold
+                await serviceRegistry.connect(serviceManager).deploy(serviceOwnerAddress, serviceId,
+                    gnosisSafeSameAddressMultisig.address, packedData);
+
+                // Check that the service is deployed
+                const service = await serviceRegistry.getService(serviceId);
+                expect(service.state).to.equal(4);
+            });
+
             it("Changing multisig for its re-deployment in a service via multisend with the multisig owner", async function () {
                 if (serviceRegistryImplementation == "l2") {
                     serviceRegistry = serviceRegistryL2;


### PR DESCRIPTION
- Adding a test showing that swap + threshold change operation when changing multisig owners is cheaper than add + remove (with threshold change) combination. 