### PR TITLE
fix: default deploy script to check for the snapshot file

### DIFF
--- a/deploy/0_deploy.js
+++ b/deploy/0_deploy.js
@@ -5,7 +5,12 @@ const { expect } = require("chai");
 module.exports = async () => {
     // Read configs from the JSON file
     const fs = require("fs");
-    const snapshotFile = "/base/scripts/mainnet_snapshot.json";
+    // Account for the default docker-originated behavior
+    let snapshotFile = "/base/scripts/mainnet_snapshot.json";
+    if (!fs.existsSync(snapshotFile)) {
+        // If the file does not exist, take the original snapshot file
+        snapshotFile = "./scripts/mainnet_snapshot.json";
+    }
     const dataFromJSON = fs.readFileSync(snapshotFile, "utf8");
     const snapshotJSON = JSON.parse(dataFromJSON);
 


### PR DESCRIPTION
- Fix the default behavior of the deploy script when it's not run with the docker image.