### PR TITLE
fix: hardhat config to get the accounts

### DIFF
--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -41,10 +41,12 @@ module.exports = {
         },
         mainnet: {
             url: "https://eth-mainnet.g.alchemy.com/v2/" + ALCHEMY_API_KEY_MAINNET,
+            accounts: accounts,
             chainId: 1,
         },
         polygon: {
             url: "https://polygon-mainnet.g.alchemy.com/v2/" + ALCHEMY_API_KEY_MATIC,
+            accounts: accounts,
             chainId: 137,
         },
         gnosis: {

--- a/scripts/deployment/l2/deploy_01_service_registry_l2.js
+++ b/scripts/deployment/l2/deploy_01_service_registry_l2.js
@@ -43,7 +43,6 @@ async function main() {
     }
 
     const provider = new ethers.providers.JsonRpcProvider(networkURL);
-    console.log(provider);
     const signers = await ethers.getSigners();
 
     if (useLedger) {


### PR DESCRIPTION
- Small fixes for the hardhat config to identify accounts correctly on mainnets when the ledger is not used.