### PR TITLE
feat and test: scripts and tests to recover funds after agent EOA access is lost

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,16 @@ Key terminology (see docs/definitions.md for details):
 
 When reading code, documentation, or contract names, use the smart contract terminology. When discussing the user-facing application, use the marketplace terminology.
 
+## Setup
+
+The project uses git submodules (`lib/forge-std`, `lib/solmate`). Clone with `git clone --recursive` or run `git submodule update --init --recursive` after cloning.
+
+```bash
+yarn install
+```
+
+Confirmed to work with Yarn 1.22.19, npm/npx 10.1.0, Node v18.17.0.
+
 ## Common Development Commands
 
 ### Build and Compile
@@ -46,8 +56,7 @@ yarn test
 # Run specific test file
 npx hardhat test test/ServiceRegistry.js
 
-# Run with gas reporter
-yarn test  # (gas reporter enabled by default in config)
+# Gas reporter is enabled by default in hardhat config
 ```
 
 #### Forge Tests (Solidity)
@@ -60,6 +69,7 @@ forge test --match-contract PolySafeCreator -vvv
 
 # Run fork tests (requires FORK_NODE_URL env var)
 forge test -f $FORK_NODE_URL --match-contract IdentityRegistry -vvv
+forge test -f $FORK_NODE_URL --match-contract StakePolySafe -vvv
 ```
 
 ### Coverage
@@ -90,6 +100,12 @@ scribble contracts/scribble/ServiceRegistryAnnotated.sol --disarm
 
 # Or use the convenience script
 ./scripts/scribble.sh scribble/ServiceRegistryAnnotated.sol
+```
+
+### Docker (Local Development)
+```bash
+docker build . -t valory/autonolas-registries
+docker run -it -d -p 8545:8545 --name chain valory/autonolas-registries
 ```
 
 ### Deployment and Network Operations
@@ -208,17 +224,36 @@ The protocol is deployed across multiple chains. See `docs/configuration.json` f
 - Reentrancy protection uses a simple `_locked` variable pattern
 - Maximum unit IDs are bounded by `uint32` (~4.2 billion)
 
+### Recovery Module & Fund Recovery
+
+When an Agent EOA private key is lost, the `RecoveryModule` contract allows the service owner (Master Safe) to regain sole ownership of the Agent Safe. The full recovery script is at `scripts/recover_funds_lost_agent_eoa.py` with detailed documentation in `docs/recover_funds_lost_agent_eoa.md`.
+
+**Recovery flow**: unstake (if staked) -> terminate -> unbond -> `recoveryModule.recoverAccess(serviceId)` -> sweep funds via MultiSend.
+
+Key contracts involved:
+- `contracts/multisigs/RecoveryModule.sol`: `recoverAccess(serviceId)` removes all Agent Safe owners and makes the service owner the sole owner
+- `contracts/multisigs/SafeMultisigWithRecoveryModule.sol`: Creates Safe proxies with the RecoveryModule pre-enabled
+- `contracts/staking/StakingBase.sol`: `unstake(serviceId)` returns service NFT to the owner. `getServiceInfo(serviceId)` exposes the actual service owner when staked.
+
+The recovery script uses Safe v=1 (sender-approved) signatures where Master Safe is both msg.sender and the sole owner. Forge tests covering all recovery scenarios are in `test/RecoverFunds.t.sol`.
+
 ## Key Files and Locations
 
 - **Contracts:** `contracts/`
 - **Tests:** `test/` (JavaScript with Hardhat), `test/*.t.sol` (Solidity with Forge)
 - **Deployment scripts:** `scripts/deployment/`
+- **Recovery script:** `scripts/recover_funds_lost_agent_eoa.py` (see `docs/recover_funds_lost_agent_eoa.md`)
 - **ABIs:** `abis/` (organized by Solidity version)
 - **Documentation:** `docs/`
+- **Contract addresses per chain:** `docs/configuration.json`
 - **Solana integration:** `integrations/solana/`
 
 ## Development Notes
 
+- When using `web3.py` with Polygon (or other POA chains), inject `geth_poa_middleware` before making calls — Polygon blocks have >32 byte `extraData` which causes `ExtraDataLengthError` without it
+- When encoding calldata for Safe transactions (without sending), use `contract.functions.func(args)._encode_transaction_data()` instead of `build_transaction()["data"]` to avoid unnecessary gas estimation RPC calls that may revert (e.g., MultiSend enforces delegatecall-only)
+- Gnosis Safe v1.3.0 signature types: `v=27/28` for ECDSA, `v=0` for contract signature, `v=1` for sender-approved (msg.sender is owner, no actual signature needed — `r=address padded to 32 bytes, s=0, v=1`)
+- `StakingBase.stake` has two overloads (`stake(uint256)` and `stake(uint256,uint256)`), so `StakingBase.stake.selector` is ambiguous in Solidity. Use `bytes4(keccak256("stake(uint256)"))` instead. Same applies to other overloaded functions.
 - The `manager` role (not `owner`) typically calls `create()` functions on registries
 - Service ownership transfers happen during deployment (service owner gives up multisig ownership to agent instances)
 - When working with service registration, always verify the state machine constraints

--- a/docs/recover_funds_lost_agent_eoa.md
+++ b/docs/recover_funds_lost_agent_eoa.md
@@ -1,0 +1,235 @@
+# Recover Funds When Agent EOA Is Lost
+
+This document describes the design and usage of `scripts/recover_funds_lost_agent_eoa.py`, a script that recovers funds from an Agent Safe (service multisig) when the Agent EOA private key has been lost.
+
+## Background
+
+In the Olas protocol, a service is deployed as a Gnosis Safe multisig (the "Agent Safe") owned by agent instance EOAs. When the Agent EOA key is lost, the service owner (Master Safe) can regain control of the Agent Safe through the RecoveryModule, and then sweep all remaining funds back to the Master Safe.
+
+### Key Actors
+
+| Actor | Description |
+|-------|-------------|
+| **Master EOA** | The externally owned account that signs transactions. Owns the Master Safe. |
+| **Master Safe** | A Gnosis Safe v1.3.0 with threshold=1. The service owner (holds the service NFT). Has at least 2 owners: Master EOA + backup address. |
+| **Agent EOA** | The agent instance EOA whose private key is **lost**. Was an owner of the Agent Safe. |
+| **Agent Safe** | The service multisig (Gnosis Safe v1.3.0) created when the service was deployed. Holds the funds to recover. |
+| **Staking Proxy** | (Optional) A staking contract that may hold the service NFT if the service is currently staked. |
+
+### Recovery Flow
+
+The script handles the full lifecycle automatically:
+
+```
+1. [If staked]  Master EOA -> Master Safe -> stakingProxy.unstake(serviceId)
+2. [If Deployed] Master EOA -> Master Safe -> serviceManager.terminate(serviceId)
+3. [If TerminatedBonded] Master EOA -> Master Safe -> serviceManager.unbond(serviceId)
+4. [If Agent Safe not owned by Master Safe] Master EOA -> Master Safe -> recoveryModule.recoverAccess(serviceId)
+5. Master EOA -> Master Safe -> Agent Safe.execTransaction(multiSend: transfer all tokens to Master Safe)
+```
+
+Each step is skipped if the service is already past that state.
+
+---
+
+## Prerequisites
+
+### Python Dependencies
+
+```bash
+pip install web3 eth_account
+```
+
+### Information Needed
+
+- **Service ID**: The on-chain service ID to recover
+- **Chain ID**: The chain where the service is deployed
+- **RPC URL**: An RPC endpoint for the target chain
+- **Master EOA key**: One of: private key file, `PRIVATE_KEY` env var, or `--impersonate` for fork testing
+
+The script auto-detects the Master Safe address from the service registry. If the service is staked, it detects the staking contract and resolves the actual owner from `stakingProxy.getServiceInfo(serviceId).owner`.
+
+### Supported Chains
+
+The script loads contract addresses from `docs/configuration.json`. Token lists for recovery are fetched at runtime from the [olas-operate-app token config](https://github.com/valory-xyz/olas-operate-app/blob/main/frontend/config/tokens.ts).
+
+| Chain | Chain ID |
+|-------|----------|
+| Ethereum | 1 |
+| Polygon | 137 |
+| Gnosis | 100 |
+| Base | 8453 |
+| Optimism | 10 |
+| Arbitrum | 42161 |
+| Celo | 42220 |
+| Mode | 34443 |
+
+---
+
+## Usage
+
+### Production Mode (with private key)
+
+```bash
+# Using a private key file
+python scripts/recover_funds_lost_agent_eoa.py \
+  --service-id 42 \
+  --chain-id 100 \
+  --rpc-url https://rpc.gnosischain.com \
+  --private-key-file /path/to/master_eoa.key
+
+# Using PRIVATE_KEY environment variable
+export PRIVATE_KEY=0xabcdef...
+export RPC_URL=https://rpc.gnosischain.com
+python scripts/recover_funds_lost_agent_eoa.py \
+  --service-id 42 \
+  --chain-id 100
+```
+
+The private key file should contain the raw hex private key (with or without `0x` prefix).
+
+### Fork Testing Mode (Tenderly / Anvil)
+
+For testing without a private key, use `--impersonate` on a fork RPC. This sends unsigned transactions that the fork accepts from any address.
+
+```bash
+# Create a Tenderly fork or Anvil fork of the target chain, then:
+python scripts/recover_funds_lost_agent_eoa.py \
+  --service-id 109 \
+  --chain-id 137 \
+  --rpc-url https://virtual.polygon.eu.rpc.tenderly.co/<fork-id> \
+  --impersonate 0xMasterEOAAddress
+```
+
+### CLI Arguments
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `--service-id` | Yes | Service ID to recover |
+| `--chain-id` | Yes | Chain ID where the service lives |
+| `--rpc-url` | No | RPC endpoint (or set `RPC_URL` env var) |
+| `--private-key-file` | No | Path to file containing the Master EOA private key |
+| `--ledger` | No | Use Ledger hardware wallet (not yet implemented) |
+| `--derivation-path` | No | Ledger derivation path (default: `m/44'/60'/0'/0/0`) |
+| `--impersonate` | No | EOA address to impersonate on fork RPCs (no signing needed) |
+
+### Example Output
+
+```
+Connected to chain 137
+Master EOA (impersonated): 0x7945E6D6665B569eaE7E8465915bBf49205C7708
+MultiSend address: 0x40A2aCCbd92BCA938b02010E17A5b8929b49130D
+
+--- Checking service ---
+Service 109:
+  NFT holder: 0xcE6192e447560A17eEB2CEc64726000bE4446179
+  Multisig (Agent Safe): 0x0FFAD2468e9Cc611761a8052791E56756Db6F137
+  State: PreRegistration (1)
+  Service owner (Master Safe): 0xcE6192e447560A17eEB2CEc64726000bE4446179
+
+--- Validating Master Safe ---
+Master Safe owners: ['0x24786ba2BF5A6dB021518fFA669eb0c63c225513', '0x7945E6D6665B569eaE7E8465915bBf49205C7708']
+Master Safe threshold: 1
+
+Agent Safe owners: ['0xcE6192e447560A17eEB2CEc64726000bE4446179']
+Agent Safe sole owner is already Master Safe. Skipping recovery.
+
+--- Recovering funds ---
+Found 3 ERC20 token(s) for chain 137:
+  OLAS: 27.46 (27463850837138520060 wei)
+  USDC: 1320.41 (1320413562 wei)
+  USDC.e: 1012.16 (1012155666 wei)
+  Native token: 2.0 (2000000000000000000 wei)
+
+Building multicall with 4 transfer(s)...
+Executing fund recovery transaction...
+  Transaction sent: 0xe335...22df9
+
+--- Recovery Summary ---
+Recovered from Agent Safe (0x0FFA...F137) to Master Safe (0xcE61...6179):
+  OLAS: 27.46
+  USDC: 1320.41
+  USDC.e: 1012.16
+  Native: 2.0
+
+All ERC20 funds recovered successfully.
+```
+
+---
+
+## How It Works
+
+### Step-by-Step
+
+1. **Service discovery**: Queries `serviceRegistry.ownerOf(serviceId)` to find the NFT holder. If the holder is a contract, tries `getServiceInfo(serviceId)` on it to detect staking. The actual service owner (Master Safe) is resolved either directly or from the staking contract's `ServiceInfo.owner` field.
+
+2. **Master Safe validation**: Verifies the Master EOA is an owner of the Master Safe and the threshold is 1 (required for single-signer execution).
+
+3. **Operator discovery**: Before any state changes, queries `serviceRegistry.getAgentInstances(serviceId)` and `mapAgentInstanceOperators()` to find all operators. This is needed for the unbond step.
+
+4. **Unstake** (if staked): Master Safe calls `stakingProxy.unstake(serviceId)`, which transfers the service NFT back to Master Safe. The service remains in Deployed state.
+
+5. **Terminate** (if Deployed/Active/FinishedRegistration): Master Safe calls `serviceManager.terminate(serviceId)`, moving the service to TerminatedBonded (if agents were registered) or PreRegistration.
+
+6. **Unbond** (if TerminatedBonded): For each operator, calls `serviceManager.unbond(serviceId)`. In the typical olas-operate-app flow, Master Safe is the operator. If an operator is not Master Safe and we're in impersonate mode, the script impersonates the operator directly. In production mode with a non-Master-Safe operator, the script errors out.
+
+7. **Recovery**: With the service in PreRegistration state, Master Safe calls `recoveryModule.recoverAccess(serviceId)`. The RecoveryModule removes all Agent Safe owners and sets Master Safe as the sole owner (threshold=1).
+
+8. **Fund transfer**: Builds a MultiSend multicall that Agent Safe executes via delegatecall, transferring all ERC20 tokens (fetched from the olas-operate-app token config) and native tokens to Master Safe. The Master Safe uses a v=1 (sender-approved) Safe signature since it is the sole owner and msg.sender.
+
+### Safe Signature Types Used
+
+- **ECDSA (v=27/28)**: Master EOA signs the Master Safe transaction hash. Used for all Master Safe `execTransaction` calls in production mode.
+- **Sender-approved (v=1)**: Used for Agent Safe's `execTransaction` where Master Safe is both the sole owner and `msg.sender`. Format: `r = masterSafe address (32 bytes) | s = 0 (32 bytes) | v = 1 (1 byte)`.
+- **Impersonate mode**: Uses v=1 sender-approved signatures on both Master Safe and Agent Safe, combined with unsigned `eth_sendTransaction` calls that Tenderly/Anvil forks accept.
+
+### Contract Dependencies
+
+All addresses are loaded from `docs/configuration.json` at runtime:
+- `ServiceRegistry` (chain 1) or `ServiceRegistryL2` (all L2 chains)
+- `RecoveryModule`
+- `ServiceManager` / `ServiceManagerProxy`
+- `MultiSend` (read from `recoveryModule.multiSend()` immutable)
+
+### Limitations
+
+- Master Safe threshold must be 1. For threshold > 1, additional owner signatures would be needed.
+- If the operator is not Master Safe, production mode cannot unbond (need operator's key). Fork testing mode can impersonate.
+- Ledger hardware wallet signing is not yet implemented.
+- Only recovers tokens listed in the olas-operate-app token config for the given chain. Other tokens in the Agent Safe are not recovered.
+
+---
+
+## Testing
+
+### Forge Tests
+
+The Solidity test `test/RecoverFunds.t.sol` covers:
+
+```bash
+forge test --match-contract RecoverFunds -vvv
+```
+
+| Test | Description |
+|------|-------------|
+| `test_recoverAccess_and_transferFunds` | Full flow: recover ownership + transfer ERC20s + native |
+| `test_skipRecovery_whenAlreadyOwner` | Skip recovery when Agent Safe already owned by Master Safe |
+| `test_recoverNativeTokenOnly` | Recover only native tokens |
+| `test_recoverAccess_multipleAgentInstances` | Recovery with 2 agent instances |
+| `test_recoverFromStakedService` | Full flow from staked state: unstake -> terminate -> unbond -> recover -> transfer |
+
+### Fork Testing with Tenderly
+
+1. Go to [Tenderly](https://dashboard.tenderly.co/) and create a Virtual TestNet fork of the target chain
+2. Copy the RPC URL
+3. Run the script with `--impersonate`:
+
+```bash
+python scripts/recover_funds_lost_agent_eoa.py \
+  --service-id <ID> \
+  --chain-id <CHAIN> \
+  --rpc-url <TENDERLY_FORK_RPC> \
+  --impersonate <MASTER_EOA_ADDRESS>
+```
+
+This lets you verify the full recovery flow without spending real funds or needing the Master EOA private key.

--- a/scripts/deployment/deploy_01_component_registry.sh
+++ b/scripts/deployment/deploy_01_component_registry.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 componentRegistryName=$(jq -r '.componentRegistryName' $globals)

--- a/scripts/deployment/deploy_02_agent_registry.sh
+++ b/scripts/deployment/deploy_02_agent_registry.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 agentRegistryName=$(jq -r '.agentRegistryName' $globals)

--- a/scripts/deployment/deploy_03_registries_manager.sh
+++ b/scripts/deployment/deploy_03_registries_manager.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 componentRegistryAddress=$(jq -r '.componentRegistryAddress' $globals)

--- a/scripts/deployment/deploy_04_service_registry.sh
+++ b/scripts/deployment/deploy_04_service_registry.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryName=$(jq -r '.serviceRegistryName' $globals)

--- a/scripts/deployment/deploy_05_operator_whitelist.sh
+++ b/scripts/deployment/deploy_05_operator_whitelist.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)

--- a/scripts/deployment/deploy_06_service_registry_token_utility.sh
+++ b/scripts/deployment/deploy_06_service_registry_token_utility.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)

--- a/scripts/deployment/deploy_07_service_manager.sh
+++ b/scripts/deployment/deploy_07_service_manager.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)

--- a/scripts/deployment/deploy_08_service_manager_proxy.sh
+++ b/scripts/deployment/deploy_08_service_manager_proxy.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)

--- a/scripts/deployment/deploy_22_recovery_module.sh
+++ b/scripts/deployment/deploy_22_recovery_module.sh
@@ -18,19 +18,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 multiSendCallOnlyAddress=$(jq -r '.multiSendCallOnlyAddress' $globals)
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 contractPath="contracts/multisigs/RecoveryModule.sol:RecoveryModule"

--- a/scripts/deployment/deploy_23_safe_multisig_with_recovery_module.sh
+++ b/scripts/deployment/deploy_23_safe_multisig_with_recovery_module.sh
@@ -19,19 +19,18 @@ gnosisSafeAddress=$(jq -r '.gnosisSafeAddress' $globals)
 gnosisSafeProxyFactoryAddress=$(jq -r '.gnosisSafeProxyFactoryAddress' $globals)
 recoveryModuleAddress=$(jq -r '.recoveryModuleAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 contractPath="contracts/multisigs/SafeMultisigWithRecoveryModule.sol:SafeMultisigWithRecoveryModule"

--- a/scripts/deployment/deploy_24_complementary_service_metadata.sh
+++ b/scripts/deployment/deploy_24_complementary_service_metadata.sh
@@ -17,19 +17,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 contractPath="contracts/utils/ComplementaryServiceMetadata.sol:ComplementaryServiceMetadata"

--- a/scripts/deployment/deploy_25_identity_registry_bridger.sh
+++ b/scripts/deployment/deploy_25_identity_registry_bridger.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 identityRegistryAddress=$(jq -r '.identityRegistryAddress' $globals)

--- a/scripts/deployment/deploy_26_identity_registry_bridger_proxy.sh
+++ b/scripts/deployment/deploy_26_identity_registry_bridger_proxy.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 identityRegistryBridgerAddress=$(jq -r '.identityRegistryBridgerAddress' $globals)

--- a/scripts/deployment/l2/deploy_01_service_registry_l2.sh
+++ b/scripts/deployment/l2/deploy_01_service_registry_l2.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryName=$(jq -r '.serviceRegistryName' $globals)

--- a/scripts/deployment/l2/deploy_02_operator_whitelist.sh
+++ b/scripts/deployment/l2/deploy_02_operator_whitelist.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)

--- a/scripts/deployment/l2/deploy_03_service_registry_token_utility.sh
+++ b/scripts/deployment/l2/deploy_03_service_registry_token_utility.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)

--- a/scripts/deployment/l2/deploy_04_service_manager.sh
+++ b/scripts/deployment/l2/deploy_04_service_manager.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)

--- a/scripts/deployment/l2/deploy_05_service_manager_proxy.sh
+++ b/scripts/deployment/l2/deploy_05_service_manager_proxy.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)

--- a/scripts/deployment/l2/deploy_06a_gnosis_safe_multisig.sh
+++ b/scripts/deployment/l2/deploy_06a_gnosis_safe_multisig.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 gnosisSafeAddress=$(jq -r '.gnosisSafeAddress' $globals)

--- a/scripts/deployment/l2/deploy_06b_gnosis_safe_same_address_multisig.sh
+++ b/scripts/deployment/l2/deploy_06b_gnosis_safe_same_address_multisig.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 multisigProxyHash130=$(jq -r '.multisigProxyHash130' $globals)

--- a/scripts/deployment/l2/deploy_16_service_staking_token.sh
+++ b/scripts/deployment/l2/deploy_16_service_staking_token.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 contractName="StakingToken"

--- a/scripts/deployment/l2/deploy_17_service_staking_native_token.sh
+++ b/scripts/deployment/l2/deploy_17_service_staking_native_token.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 contractName="StakingNativeToken"

--- a/scripts/deployment/l2/deploy_18_service_staking_verifier.sh
+++ b/scripts/deployment/l2/deploy_18_service_staking_verifier.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 olasAddress=$(jq -r '.olasAddress' $globals)

--- a/scripts/deployment/l2/deploy_19_service_staking_factory.sh
+++ b/scripts/deployment/l2/deploy_19_service_staking_factory.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 stakingVerifierAddress=$(jq -r '.stakingVerifierAddress' $globals)

--- a/scripts/deployment/l2/deploy_20_staking_verifier_set_implementations.sh
+++ b/scripts/deployment/l2/deploy_20_staking_verifier_set_implementations.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 stakingVerifierAddress=$(jq -r '.stakingVerifierAddress' $globals)
 stakingTokenAddress=$(jq -r '.stakingTokenAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/deploy_21_22_service_staking_change_ownerships.sh
+++ b/scripts/deployment/l2/deploy_21_22_service_staking_change_ownerships.sh
@@ -28,19 +28,18 @@ stakingVerifierAddress=$(jq -r '.stakingVerifierAddress' $globals)
 stakingFactoryAddress=$(jq -r '.stakingFactoryAddress' $globals)
 bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/deploy_23_hash_checkpoint_l2.sh
+++ b/scripts/deployment/l2/deploy_23_hash_checkpoint_l2.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 baseURI=$(jq -r '.baseURI' $globals)

--- a/scripts/deployment/l2/deploy_24_recovery_module.sh
+++ b/scripts/deployment/l2/deploy_24_recovery_module.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 multiSendCallOnlyAddress=$(jq -r '.multiSendCallOnlyAddress' $globals)

--- a/scripts/deployment/l2/deploy_25_safe_multisig_with_recovery_module.sh
+++ b/scripts/deployment/l2/deploy_25_safe_multisig_with_recovery_module.sh
@@ -18,19 +18,18 @@ gnosisSafeAddress=$(jq -r '.gnosisSafeAddress' $globals)
 gnosisSafeProxyFactoryAddress=$(jq -r '.gnosisSafeProxyFactoryAddress' $globals)
 recoveryModuleAddress=$(jq -r '.recoveryModuleAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 contractName="SafeMultisigWithRecoveryModule"

--- a/scripts/deployment/l2/deploy_26_complementary_service_metadata.sh
+++ b/scripts/deployment/l2/deploy_26_complementary_service_metadata.sh
@@ -17,19 +17,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 contractPath="contracts/utils/ComplementaryServiceMetadata.sol:ComplementaryServiceMetadata"

--- a/scripts/deployment/l2/deploy_27_identity_registry_bridger.sh
+++ b/scripts/deployment/l2/deploy_27_identity_registry_bridger.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 identityRegistryAddress=$(jq -r '.identityRegistryAddress' $globals)

--- a/scripts/deployment/l2/deploy_28_identity_registry_bridger_proxy.sh
+++ b/scripts/deployment/l2/deploy_28_identity_registry_bridger_proxy.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 identityRegistryBridgerAddress=$(jq -r '.identityRegistryBridgerAddress' $globals)

--- a/scripts/deployment/l2/deploy_29_poly_safe_creator_with_recovery_module.sh
+++ b/scripts/deployment/l2/deploy_29_poly_safe_creator_with_recovery_module.sh
@@ -18,19 +18,18 @@ polySafeProxyFactoryAddress=$(jq -r '.polySafeProxyFactoryAddress' $globals)
 recoveryModuleAddress=$(jq -r '.recoveryModuleAddress' $globals)
 polySafeProxyBytecodeHash=$(jq -r '.polySafeProxyBytecodeHash' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 contractName="PolySafeCreatorWithRecoveryModule"

--- a/scripts/deployment/l2/deploy_30_poly_safe_same_address_multisig.sh
+++ b/scripts/deployment/l2/deploy_30_poly_safe_same_address_multisig.sh
@@ -14,19 +14,18 @@ derivationPath=$(jq -r '.derivationPath' $globals)
 chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 polySafeProxyBytecodeHash=$(jq -r '.polySafeProxyBytecodeHash' $globals)

--- a/scripts/deployment/l2/script_l2_01_whitelist_multisig_implementations.sh
+++ b/scripts/deployment/l2/script_l2_01_whitelist_multisig_implementations.sh
@@ -28,19 +28,18 @@ serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 safeMultisigWithRecoveryModuleAddress=$(jq -r '.safeMultisigWithRecoveryModuleAddress' $globals)
 recoveryModuleAddress=$(jq -r '.recoveryModuleAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_02_change_managers_registries.sh
+++ b/scripts/deployment/l2/script_l2_02_change_managers_registries.sh
@@ -28,19 +28,18 @@ serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 serviceRegistryTokenUtilityAddress=$(jq -r '.serviceRegistryTokenUtilityAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_03_service_manager_change_operator_whitelist.sh
+++ b/scripts/deployment/l2/script_l2_03_service_manager_change_operator_whitelist.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 operatorWhitelistAddress=$(jq -r '.operatorWhitelistAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_04_service_manager_change_implementation.sh
+++ b/scripts/deployment/l2/script_l2_04_service_manager_change_implementation.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_05_change_service_manager_identity_registry_bridger.sh
+++ b/scripts/deployment/l2/script_l2_05_change_service_manager_identity_registry_bridger.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_06_identity_registry_bridger_change_implementation.sh
+++ b/scripts/deployment/l2/script_l2_06_identity_registry_bridger_change_implementation.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 identityRegistryBridgerAddress=$(jq -r '.identityRegistryBridgerAddress' $globals)
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_8004_initiation.sh
+++ b/scripts/deployment/l2/script_l2_8004_initiation.sh
@@ -29,19 +29,18 @@ serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/l2/script_l2_service_manager_update.sh
+++ b/scripts/deployment/l2/script_l2_service_manager_update.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 
-# Check for Polygon keys only since on other networks those are not needed
-if [ $chainId == 137 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MATIC
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MATIC env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 80002 ]; then
-    API_KEY=$ALCHEMY_API_KEY_AMOY
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_AMOY env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_01_whitelist_multisig_implementations.sh
+++ b/scripts/deployment/script_l1_01_whitelist_multisig_implementations.sh
@@ -28,19 +28,18 @@ serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 safeMultisigWithRecoveryModuleAddress=$(jq -r '.safeMultisigWithRecoveryModuleAddress' $globals)
 recoveryModuleAddress=$(jq -r '.recoveryModuleAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_02_change_managers_registries.sh
+++ b/scripts/deployment/script_l1_02_change_managers_registries.sh
@@ -31,19 +31,18 @@ serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
 serviceRegistryTokenUtilityAddress=$(jq -r '.serviceRegistryTokenUtilityAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_03_service_manager_change_operator_whitelist.sh
+++ b/scripts/deployment/script_l1_03_service_manager_change_operator_whitelist.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 operatorWhitelistAddress=$(jq -r '.operatorWhitelistAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_04_service_manager_change_implementation.sh
+++ b/scripts/deployment/script_l1_04_service_manager_change_implementation.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_05_change_service_manager_identity_registry_bridger.sh
+++ b/scripts/deployment/script_l1_05_change_service_manager_identity_registry_bridger.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_06_identity_registry_bridger_change_implementation.sh
+++ b/scripts/deployment/script_l1_06_identity_registry_bridger_change_implementation.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 identityRegistryBridgerAddress=$(jq -r '.identityRegistryBridgerAddress' $globals)
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_8004_initiation.sh
+++ b/scripts/deployment/script_l1_8004_initiation.sh
@@ -29,19 +29,18 @@ serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/deployment/script_l1_service_manager_update.sh
+++ b/scripts/deployment/script_l1_service_manager_update.sh
@@ -27,19 +27,18 @@ networkURL=$(jq -r '.networkURL' $globals)
 serviceManagerAddress=$(jq -r '.serviceManagerAddress' $globals)
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 
-# Getting L1 API key
-if [ $chainId == 1 ]; then
-  API_KEY=$ALCHEMY_API_KEY_MAINNET
-  if [ "$API_KEY" == "" ]; then
-      echo "set ALCHEMY_API_KEY_MAINNET env variable"
-      exit 0
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 0
   fi
-elif [ $chainId == 11155111 ]; then
-    API_KEY=$ALCHEMY_API_KEY_SEPOLIA
-    if [ "$API_KEY" == "" ]; then
-        echo "set ALCHEMY_API_KEY_SEPOLIA env variable"
-        exit 0
-    fi
 fi
 
 # Get deployer based on the ledger flag

--- a/scripts/recover_funds_lost_agent_eoa.py
+++ b/scripts/recover_funds_lost_agent_eoa.py
@@ -1,0 +1,1144 @@
+#!/usr/bin/env python3
+"""
+Recover funds from an Agent Safe after gaining ownership via RecoveryModule.
+
+Full flow (handles staked services automatically):
+  1. If service is staked: Master Safe -> stakingProxy.unstake(serviceId)
+  2. If service is Deployed: Master Safe -> serviceManager.terminate(serviceId)
+  3. If service is TerminatedBonded: Master Safe -> serviceManager.unbond(serviceId) per operator
+  4. Master Safe -> recoveryModule.recoverAccess(serviceId) (makes Master Safe sole owner of Agent Safe)
+  5. Master EOA -> Master Safe -> Agent Safe.execTransaction(multiSend transfer all tokens)
+
+Usage:
+  python recover_funds_lost_agent_eoa.py --service-id 42 --chain-id 100
+  python recover_funds_lost_agent_eoa.py --service-id 42 --chain-id 100 --private-key-file /path/to/key
+  python recover_funds_lost_agent_eoa.py --service-id 42 --chain-id 100 --ledger --derivation-path "m/44'/60'/0'/0/0"
+
+Testing on a Tenderly/Anvil fork (no private key needed):
+  python recover_funds_lost_agent_eoa.py --service-id 42 --chain-id 100 \
+    --rpc-url https://rpc.tenderly.co/fork/... --impersonate 0xMasterEOA
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.request
+import warnings
+from pathlib import Path
+
+# Suppress eth_utils network warnings about unknown chain IDs
+warnings.filterwarnings("ignore", message="Network .* does not have a valid ChainId", category=UserWarning)
+
+from web3 import Web3
+from web3.middleware import geth_poa_middleware
+from eth_account import Account
+
+# ---------------------------------------------------------------------------
+# Minimal ABIs (only the functions we call)
+# ---------------------------------------------------------------------------
+
+SAFE_ABI = json.loads("""[
+  {
+    "inputs": [],
+    "name": "getOwners",
+    "outputs": [{"internalType": "address[]", "name": "", "type": "address[]"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getThreshold",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "nonce",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "to", "type": "address"},
+      {"internalType": "uint256", "name": "value", "type": "uint256"},
+      {"internalType": "bytes", "name": "data", "type": "bytes"},
+      {"internalType": "uint8", "name": "operation", "type": "uint8"},
+      {"internalType": "uint256", "name": "safeTxGas", "type": "uint256"},
+      {"internalType": "uint256", "name": "baseGas", "type": "uint256"},
+      {"internalType": "uint256", "name": "gasPrice", "type": "uint256"},
+      {"internalType": "address", "name": "gasToken", "type": "address"},
+      {"internalType": "address payable", "name": "refundReceiver", "type": "address"},
+      {"internalType": "bytes", "name": "signatures", "type": "bytes"}
+    ],
+    "name": "execTransaction",
+    "outputs": [{"internalType": "bool", "name": "success", "type": "bool"}],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "to", "type": "address"},
+      {"internalType": "uint256", "name": "value", "type": "uint256"},
+      {"internalType": "bytes", "name": "data", "type": "bytes"},
+      {"internalType": "uint8", "name": "operation", "type": "uint8"},
+      {"internalType": "uint256", "name": "safeTxGas", "type": "uint256"},
+      {"internalType": "uint256", "name": "baseGas", "type": "uint256"},
+      {"internalType": "uint256", "name": "gasPrice", "type": "uint256"},
+      {"internalType": "address", "name": "gasToken", "type": "address"},
+      {"internalType": "address", "name": "refundReceiver", "type": "address"},
+      {"internalType": "uint256", "name": "_nonce", "type": "uint256"}
+    ],
+    "name": "getTransactionHash",
+    "outputs": [{"internalType": "bytes32", "name": "", "type": "bytes32"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]""")
+
+SERVICE_REGISTRY_ABI = json.loads("""[
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "mapServices",
+    "outputs": [
+      {"internalType": "uint96", "name": "securityDeposit", "type": "uint96"},
+      {"internalType": "address", "name": "multisig", "type": "address"},
+      {"internalType": "bytes32", "name": "configHash", "type": "bytes32"},
+      {"internalType": "uint32", "name": "threshold", "type": "uint32"},
+      {"internalType": "uint32", "name": "maxNumAgentInstances", "type": "uint32"},
+      {"internalType": "uint32", "name": "numAgentInstances", "type": "uint32"},
+      {"internalType": "uint8", "name": "state", "type": "uint8"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "tokenId", "type": "uint256"}],
+    "name": "ownerOf",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "getAgentInstances",
+    "outputs": [
+      {"internalType": "uint256", "name": "numAgentInstances", "type": "uint256"},
+      {"internalType": "address[]", "name": "agentInstances", "type": "address[]"}
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "name": "mapAgentInstanceOperators",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]""")
+
+RECOVERY_MODULE_ABI = json.loads("""[
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "recoverAccess",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "multiSend",
+    "outputs": [{"internalType": "address", "name": "", "type": "address"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]""")
+
+MULTISEND_ABI = json.loads("""[
+  {
+    "inputs": [{"internalType": "bytes", "name": "transactions", "type": "bytes"}],
+    "name": "multiSend",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  }
+]""")
+
+ERC20_ABI = json.loads("""[
+  {
+    "inputs": [{"internalType": "address", "name": "account", "type": "address"}],
+    "name": "balanceOf",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {"internalType": "address", "name": "to", "type": "address"},
+      {"internalType": "uint256", "name": "amount", "type": "uint256"}
+    ],
+    "name": "transfer",
+    "outputs": [{"internalType": "bool", "name": "", "type": "bool"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "symbol",
+    "outputs": [{"internalType": "string", "name": "", "type": "string"}],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "decimals",
+    "outputs": [{"internalType": "uint8", "name": "", "type": "uint8"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]""")
+
+STAKING_ABI = json.loads("""[
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "getServiceInfo",
+    "outputs": [
+      {
+        "components": [
+          {"internalType": "address", "name": "multisig", "type": "address"},
+          {"internalType": "address", "name": "owner", "type": "address"},
+          {"internalType": "uint256[]", "name": "nonces", "type": "uint256[]"},
+          {"internalType": "uint256", "name": "tsStart", "type": "uint256"},
+          {"internalType": "uint256", "name": "reward", "type": "uint256"},
+          {"internalType": "uint256", "name": "inactivity", "type": "uint256"},
+          {"internalType": "uint256", "name": "rewardDistributionInfo", "type": "uint256"}
+        ],
+        "internalType": "struct ServiceInfo",
+        "name": "sInfo",
+        "type": "tuple"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "unstake",
+    "outputs": [{"internalType": "uint256", "name": "", "type": "uint256"}],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "getStakingState",
+    "outputs": [{"internalType": "uint8", "name": "stakingState", "type": "uint8"}],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]""")
+
+SERVICE_MANAGER_ABI = json.loads("""[
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "terminate",
+    "outputs": [
+      {"internalType": "bool", "name": "success", "type": "bool"},
+      {"internalType": "uint256", "name": "refund", "type": "uint256"}
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [{"internalType": "uint256", "name": "serviceId", "type": "uint256"}],
+    "name": "unbond",
+    "outputs": [
+      {"internalType": "bool", "name": "success", "type": "bool"},
+      {"internalType": "uint256", "name": "refund", "type": "uint256"}
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]""")
+
+ZERO_ADDRESS = "0x0000000000000000000000000000000000000000"
+
+# Safe operation types
+CALL = 0
+DELEGATECALL = 1  # Required for MultiSend (it enforces delegatecall-only via singleton check)
+
+# Service states from ServiceRegistryL2
+SERVICE_STATE_NAMES = {
+    0: "NonExistent",
+    1: "PreRegistration",
+    2: "ActiveRegistration",
+    3: "FinishedRegistration",
+    4: "Deployed",
+    5: "TerminatedBonded",
+}
+
+# Staking states from StakingBase
+STAKING_STATE_NAMES = {
+    0: "Unstaked",
+    1: "Staked",
+    2: "Evicted",
+}
+
+# Token config URL
+TOKENS_TS_URL = "https://raw.githubusercontent.com/valory-xyz/olas-operate-app/main/frontend/config/tokens.ts"
+
+
+# ---------------------------------------------------------------------------
+# Token fetching
+# ---------------------------------------------------------------------------
+
+def fetch_url(url: str) -> str:
+    """Fetch text content from a URL."""
+    req = urllib.request.Request(url, headers={"User-Agent": "recover_funds_lost_agent_eoa.py"})
+    with urllib.request.urlopen(req, timeout=30) as resp:
+        return resp.read().decode("utf-8")
+
+
+
+def parse_tokens(tokens_ts: str) -> dict:
+    """
+    Parse tokens.ts to extract ERC20 token addresses per chain config block.
+    Returns: {chain_config_name: [{"address": "0x...", "symbol": "...", "decimals": N}, ...]}
+    """
+    chain_configs = {}
+
+    # Match each *_TOKEN_CONFIG block by finding the opening brace and balancing
+    config_pattern = re.compile(
+        r"(?:const|export\s+const)\s+(\w+_TOKEN_CONFIG)\s*:\s*ChainTokenConfig\s*=\s*\{",
+    )
+
+    for config_match in config_pattern.finditer(tokens_ts):
+        config_name = config_match.group(1)
+        # Find the balanced closing brace for this config block
+        start = config_match.end()
+        depth = 1
+        pos = start
+        while pos < len(tokens_ts) and depth > 0:
+            if tokens_ts[pos] == "{":
+                depth += 1
+            elif tokens_ts[pos] == "}":
+                depth -= 1
+            pos += 1
+        config_body = tokens_ts[start:pos - 1]
+
+        tokens = []
+
+        # Match token entries with both dot notation and bracket notation:
+        #   [TokenSymbolMap.OLAS]: { ... }
+        #   [TokenSymbolMap['USDC.e']]: { ... }
+        entry_pattern = re.compile(
+            r"\[TokenSymbolMap(?:\.(\w+)|\[['\"]([^'\"]+)['\"]\])\]\s*:\s*\{",
+            re.DOTALL,
+        )
+
+        for entry_match in entry_pattern.finditer(config_body):
+            symbol = entry_match.group(1) or entry_match.group(2)
+
+            # Extract the entry body by finding balanced braces
+            entry_start = entry_match.end()
+            depth = 1
+            epos = entry_start
+            while epos < len(config_body) and depth > 0:
+                if config_body[epos] == "{":
+                    depth += 1
+                elif config_body[epos] == "}":
+                    depth -= 1
+                epos += 1
+            entry_body = config_body[entry_start:epos - 1]
+
+            # Skip native gas tokens (no address field)
+            address_match = re.search(r"address\s*:\s*['\"]([^'\"]+)['\"]", entry_body)
+            if not address_match:
+                continue
+
+            address = address_match.group(1)
+            decimals_match = re.search(r"decimals\s*:\s*(\d+)", entry_body)
+            decimals = int(decimals_match.group(1)) if decimals_match else 18
+
+            tokens.append({
+                "address": address,
+                "symbol": symbol,
+                "decimals": decimals,
+            })
+
+        chain_configs[config_name] = tokens
+
+    return chain_configs
+
+
+def fetch_token_config(chain_id: int) -> list:
+    """
+    Fetch and parse token configuration from the olas-operate-app repo.
+    Returns list of ERC20 tokens for the given chain ID: [{"address": ..., "symbol": ..., "decimals": ...}]
+    """
+    # Map chain IDs to config block names
+    chain_id_to_config = {
+        1: "ETHEREUM_TOKEN_CONFIG",
+        100: "GNOSIS_TOKEN_CONFIG",
+        8453: "BASE_TOKEN_CONFIG",
+        34443: "MODE_TOKEN_CONFIG",
+        10: "OPTIMISM_TOKEN_CONFIG",
+        137: "POLYGON_TOKEN_CONFIG",
+        42220: "CELO_TOKEN_CONFIG",
+    }
+
+    config_name = chain_id_to_config.get(chain_id)
+    if not config_name:
+        print(f"WARNING: No token config mapping for chain ID {chain_id}. No ERC20 tokens will be recovered.")
+        return []
+
+    print(f"Fetching token configuration from {TOKENS_TS_URL} ...")
+    try:
+        tokens_ts = fetch_url(TOKENS_TS_URL)
+    except Exception as e:
+        print(f"WARNING: Failed to fetch token config: {e}. No ERC20 tokens will be recovered.")
+        return []
+
+    chain_configs = parse_tokens(tokens_ts)
+    tokens = chain_configs.get(config_name, [])
+
+    if not tokens:
+        print(f"WARNING: No ERC20 tokens found for {config_name} (chain {chain_id}).")
+    else:
+        print(f"Found {len(tokens)} ERC20 token(s) for chain {chain_id}:")
+        for t in tokens:
+            print(f"  {t['symbol']}: {t['address']} ({t['decimals']} decimals)")
+
+    return tokens
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+def load_configuration(chain_id: int) -> dict:
+    """Load contract addresses from docs/configuration.json for the given chain."""
+    config_path = Path(__file__).resolve().parent.parent / "docs" / "configuration.json"
+    with open(config_path) as f:
+        configs = json.load(f)
+
+    for chain_config in configs:
+        if str(chain_config["chainId"]) == str(chain_id):
+            contracts = {}
+            for c in chain_config["contracts"]:
+                contracts[c["name"]] = c["address"]
+            return contracts
+
+    print(f"ERROR: Chain ID {chain_id} not found in {config_path}")
+    sys.exit(1)
+
+
+def get_service_registry_name(chain_id: int) -> str:
+    """Return the service registry contract name for the chain."""
+    return "ServiceRegistry" if chain_id == 1 else "ServiceRegistryL2"
+
+
+# ---------------------------------------------------------------------------
+# Safe transaction helpers
+# ---------------------------------------------------------------------------
+
+def encode_function_data(contract_func) -> bytes:
+    """Encode a contract function call to raw bytes calldata (no gas estimation)."""
+    data = contract_func._encode_transaction_data()
+    return bytes.fromhex(data[2:] if data.startswith("0x") else data)
+
+
+def encode_multisend_txs(txs: list) -> bytes:
+    """
+    Encode transactions for MultiSend.multiSend().
+    Each tx: {to, value, data, operation}
+    Packed format: uint8 operation | address to | uint256 value | uint256 dataLength | bytes data
+    """
+    packed = b""
+    for tx in txs:
+        operation = tx.get("operation", CALL)
+        to_addr = bytes.fromhex(tx["to"][2:])
+        value = tx.get("value", 0)
+        data = tx.get("data", b"")
+        if isinstance(data, str):
+            data = bytes.fromhex(data[2:] if data.startswith("0x") else data)
+
+        packed += (
+            operation.to_bytes(1, "big")
+            + to_addr
+            + value.to_bytes(32, "big")
+            + len(data).to_bytes(32, "big")
+            + data
+        )
+    return packed
+
+
+def build_safe_signature_for_eoa(account, tx_hash: bytes) -> bytes:
+    """Build ECDSA signature (v=27/28) for an EOA signing a Safe tx hash."""
+    signed = account.signHash(tx_hash)
+    # Pack r (32 bytes) + s (32 bytes) + v (1 byte)
+    return (
+        signed.r.to_bytes(32, "big")
+        + signed.s.to_bytes(32, "big")
+        + signed.v.to_bytes(1, "big")
+    )
+
+
+def build_safe_signature_for_approved_owner(owner_address: str) -> bytes:
+    """
+    Build v=1 (sender-approved) signature for a Safe owner that is msg.sender.
+    r = owner address padded to 32 bytes, s = 0, v = 1
+    """
+    return (
+        bytes.fromhex(owner_address[2:]).rjust(32, b"\x00")
+        + b"\x00" * 32
+        + b"\x01"
+    )
+
+
+def exec_safe_tx(w3, safe_contract, account, to, value, data, operation):
+    """
+    Build, sign, and send a Safe execTransaction from an EOA owner.
+    Returns the transaction receipt.
+    """
+    nonce = safe_contract.functions.nonce().call()
+
+    tx_hash = safe_contract.functions.getTransactionHash(
+        to, value, data, operation,
+        0, 0, 0,  # safeTxGas, baseGas, gasPrice
+        ZERO_ADDRESS, ZERO_ADDRESS,  # gasToken, refundReceiver
+        nonce,
+    ).call()
+
+    signature = build_safe_signature_for_eoa(account, tx_hash)
+
+    tx = safe_contract.functions.execTransaction(
+        to, value, data, operation,
+        0, 0, 0,
+        ZERO_ADDRESS, ZERO_ADDRESS,
+        signature,
+    ).build_transaction({
+        "from": account.address,
+        "nonce": w3.eth.get_transaction_count(account.address),
+        "gas": 0,  # will be estimated
+    })
+
+    # Estimate gas
+    tx["gas"] = w3.eth.estimate_gas(tx)
+
+    signed_tx = account.sign_transaction(tx)
+    tx_hash_sent = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+    print(f"  Transaction sent: {tx_hash_sent.hex()}")
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash_sent)
+    return receipt
+
+
+def exec_safe_tx_impersonated(w3, safe_contract, sender_address, to, value, data, operation):
+    """
+    Build and send a Safe execTransaction via unsigned eth_sendTransaction
+    (for Tenderly/Anvil forks where any address can be impersonated).
+    Returns the transaction receipt.
+    """
+    nonce = safe_contract.functions.nonce().call()
+
+    tx_hash = safe_contract.functions.getTransactionHash(
+        to, value, data, operation,
+        0, 0, 0,
+        ZERO_ADDRESS, ZERO_ADDRESS,
+        nonce,
+    ).call()
+
+    # Use v=1 sender-approved signature: since sender_address is msg.sender and an owner,
+    # Safe's checkNSignatures accepts this without an actual ECDSA signature
+    signature = build_safe_signature_for_approved_owner(sender_address)
+
+    tx = safe_contract.functions.execTransaction(
+        to, value, data, operation,
+        0, 0, 0,
+        ZERO_ADDRESS, ZERO_ADDRESS,
+        signature,
+    ).build_transaction({
+        "from": sender_address,
+        "nonce": w3.eth.get_transaction_count(sender_address),
+        "gas": 0,
+    })
+
+    tx["gas"] = w3.eth.estimate_gas(tx)
+
+    # Send unsigned — Tenderly/Anvil forks accept this for any address
+    tx_hash_sent = w3.eth.send_transaction(tx)
+    print(f"  Transaction sent: {tx_hash_sent.hex()}")
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash_sent)
+    return receipt
+
+
+def send_tx_impersonated(w3, sender_address, to, data):
+    """
+    Send an unsigned transaction impersonating sender_address (for Tenderly/Anvil forks).
+    Returns the transaction receipt.
+    """
+    tx = {
+        "from": sender_address,
+        "to": to,
+        "data": data,
+        "nonce": w3.eth.get_transaction_count(sender_address),
+        "gas": 0,
+    }
+    tx["gas"] = w3.eth.estimate_gas(tx)
+    tx_hash_sent = w3.eth.send_transaction(tx)
+    print(f"  Transaction sent: {tx_hash_sent.hex()}")
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash_sent)
+    return receipt
+
+
+def send_tx_signed(w3, account, to, data):
+    """
+    Sign and send a transaction from account.
+    Returns the transaction receipt.
+    """
+    tx = {
+        "from": account.address,
+        "to": Web3.to_checksum_address(to),
+        "data": data,
+        "nonce": w3.eth.get_transaction_count(account.address),
+        "gas": 0,
+    }
+    tx["gas"] = w3.eth.estimate_gas(tx)
+    signed_tx = account.sign_transaction(tx)
+    tx_hash_sent = w3.eth.send_raw_transaction(signed_tx.raw_transaction)
+    print(f"  Transaction sent: {tx_hash_sent.hex()}")
+    receipt = w3.eth.wait_for_transaction_receipt(tx_hash_sent)
+    return receipt
+
+
+# ---------------------------------------------------------------------------
+# Key loading
+# ---------------------------------------------------------------------------
+
+def load_account(args) -> Account:
+    """Load the Master EOA account from private key file, env var, or ledger."""
+    if args.ledger:
+        print("ERROR: Ledger support is not yet implemented.")
+        print("  Please use --private-key-file or PRIVATE_KEY env variable instead.")
+        sys.exit(1)
+
+    private_key = None
+    if args.private_key_file:
+        key_path = Path(args.private_key_file)
+        if not key_path.exists():
+            print(f"ERROR: Private key file not found: {key_path}")
+            sys.exit(1)
+        private_key = key_path.read_text().strip()
+    else:
+        private_key = os.environ.get("PRIVATE_KEY")
+
+    if not private_key:
+        print("ERROR: No private key provided.")
+        print("  Use --private-key-file, set PRIVATE_KEY env var, or use --ledger")
+        sys.exit(1)
+
+    if not private_key.startswith("0x"):
+        private_key = "0x" + private_key
+
+    account = Account.from_key(private_key)
+    print(f"Master EOA: {account.address}")
+    return account
+
+
+# ---------------------------------------------------------------------------
+# Staking detection
+# ---------------------------------------------------------------------------
+
+def detect_staking(w3, nft_holder_address, service_id):
+    """
+    Check if the service NFT holder is a staking contract.
+    Returns (is_staked, staking_contract_or_None, actual_owner_address).
+
+    If the NFT holder is a staking proxy, getServiceInfo(serviceId).owner gives the actual service owner.
+    If the NFT holder is not a staking contract, it IS the actual owner (Master Safe).
+    """
+    # If NFT holder has no code, it's an EOA (the actual owner)
+    code = w3.eth.get_code(nft_holder_address)
+    if code == b"" or code == b"\x00":
+        return False, None, nft_holder_address
+
+    # Try calling getServiceInfo on the NFT holder — if it works, it's a staking contract
+    staking_contract = w3.eth.contract(address=nft_holder_address, abi=STAKING_ABI)
+    try:
+        sinfo = staking_contract.functions.getServiceInfo(service_id).call()
+        # sinfo is a tuple: (multisig, owner, nonces, tsStart, reward, inactivity, rewardDistributionInfo)
+        actual_owner = sinfo[1]
+        if actual_owner != ZERO_ADDRESS:
+            return True, staking_contract, actual_owner
+    except Exception:
+        pass
+
+    # Not a staking contract — the NFT holder is the actual owner
+    return False, None, nft_holder_address
+
+
+# ---------------------------------------------------------------------------
+# Operator discovery
+# ---------------------------------------------------------------------------
+
+def get_service_operators(service_registry, service_id):
+    """
+    Get unique operator addresses for a service by querying agent instances.
+    Returns list of unique operator addresses.
+    Must be called while the service still has agent instances (before terminate deletes them).
+    """
+    try:
+        num_instances, agent_instances = service_registry.functions.getAgentInstances(service_id).call()
+    except Exception:
+        return []
+
+    operators = set()
+    for instance in agent_instances:
+        try:
+            operator = service_registry.functions.mapAgentInstanceOperators(instance).call()
+            if operator != ZERO_ADDRESS:
+                operators.add(operator)
+        except Exception:
+            pass
+
+    return list(operators)
+
+
+# ---------------------------------------------------------------------------
+# Main logic
+# ---------------------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Recover funds from an Agent Safe via RecoveryModule"
+    )
+    parser.add_argument("--service-id", required=True, type=int, help="Service ID to recover")
+    parser.add_argument("--chain-id", required=True, type=int, help="Chain ID")
+    parser.add_argument("--rpc-url", help="RPC URL (or set RPC_URL env var)")
+    parser.add_argument("--private-key-file", help="Path to file containing private key")
+    parser.add_argument("--ledger", action="store_true", help="Use Ledger hardware wallet")
+    parser.add_argument("--derivation-path", default="m/44'/60'/0'/0/0",
+                        help="Ledger derivation path (default: m/44'/60'/0'/0/0)")
+    parser.add_argument("--impersonate", metavar="EOA_ADDRESS",
+                        help="Impersonate an EOA address on a fork RPC (Tenderly/Anvil). "
+                             "No private key needed. Sends unsigned transactions.")
+    args = parser.parse_args()
+
+    # --- Setup ---
+    rpc_url = args.rpc_url or os.environ.get("RPC_URL")
+    if not rpc_url:
+        print("ERROR: No RPC URL provided. Use --rpc-url or set RPC_URL env var.")
+        sys.exit(1)
+
+    w3 = Web3(Web3.HTTPProvider(rpc_url))
+    # Inject POA middleware for chains like Polygon that have >32 byte extraData
+    w3.middleware_onion.inject(geth_poa_middleware, layer=0)
+    if not w3.is_connected():
+        print(f"ERROR: Cannot connect to RPC at {rpc_url}")
+        sys.exit(1)
+
+    on_chain_id = w3.eth.chain_id
+    if on_chain_id != args.chain_id:
+        print(f"ERROR: RPC chain ID ({on_chain_id}) does not match --chain-id ({args.chain_id})")
+        sys.exit(1)
+
+    print(f"Connected to chain {args.chain_id}")
+
+    impersonate_mode = bool(args.impersonate)
+    if impersonate_mode:
+        master_eoa_address = Web3.to_checksum_address(args.impersonate)
+        account = None
+        print(f"Master EOA (impersonated): {master_eoa_address}")
+    else:
+        account = load_account(args)
+        master_eoa_address = account.address
+
+    service_id = args.service_id
+
+    # Load contract addresses from configuration.json
+    contracts = load_configuration(args.chain_id)
+
+    registry_name = get_service_registry_name(args.chain_id)
+    if registry_name not in contracts:
+        print(f"ERROR: {registry_name} not found in configuration for chain {args.chain_id}")
+        sys.exit(1)
+    if "RecoveryModule" not in contracts:
+        print(f"ERROR: RecoveryModule not found in configuration for chain {args.chain_id}")
+        sys.exit(1)
+
+    service_registry = w3.eth.contract(
+        address=Web3.to_checksum_address(contracts[registry_name]),
+        abi=SERVICE_REGISTRY_ABI,
+    )
+    recovery_module = w3.eth.contract(
+        address=Web3.to_checksum_address(contracts["RecoveryModule"]),
+        abi=RECOVERY_MODULE_ABI,
+    )
+
+    # Get ServiceManager address (proxy)
+    sm_name = "ServiceManagerProxy" if "ServiceManagerProxy" in contracts else "ServiceManager"
+    if sm_name not in contracts:
+        print(f"ERROR: ServiceManager/ServiceManagerProxy not found in configuration for chain {args.chain_id}")
+        sys.exit(1)
+    service_manager = w3.eth.contract(
+        address=Web3.to_checksum_address(contracts[sm_name]),
+        abi=SERVICE_MANAGER_ABI,
+    )
+
+    # Read MultiSend address from the RecoveryModule (immutable)
+    multisend_addr = recovery_module.functions.multiSend().call()
+    print(f"MultiSend address: {multisend_addr}")
+    multisend = w3.eth.contract(address=multisend_addr, abi=MULTISEND_ABI)
+
+    # --- Step 1: Get Service Info & Detect Staking ---
+    print("\n--- Checking service ---")
+    service_info = service_registry.functions.mapServices(service_id).call()
+    agent_safe_addr = service_info[1]  # multisig field
+    service_state = service_info[6]    # state field
+
+    if agent_safe_addr == ZERO_ADDRESS:
+        print(f"ERROR: Service {service_id} has no multisig (zero address). Has it been deployed?")
+        sys.exit(1)
+
+    nft_holder = service_registry.functions.ownerOf(service_id).call()
+    state_name = SERVICE_STATE_NAMES.get(service_state, f"Unknown({service_state})")
+    print(f"Service {service_id}:")
+    print(f"  NFT holder: {nft_holder}")
+    print(f"  Multisig (Agent Safe): {agent_safe_addr}")
+    print(f"  State: {state_name} ({service_state})")
+
+    # Detect if service is staked
+    is_staked, staking_contract, master_safe_addr = detect_staking(w3, nft_holder, service_id)
+    master_safe_addr = Web3.to_checksum_address(master_safe_addr)
+
+    if is_staked:
+        staking_state = staking_contract.functions.getStakingState(service_id).call()
+        staking_state_name = STAKING_STATE_NAMES.get(staking_state, f"Unknown({staking_state})")
+        print(f"  Staking contract: {nft_holder}")
+        print(f"  Staking state: {staking_state_name} ({staking_state})")
+        print(f"  Actual service owner (Master Safe): {master_safe_addr}")
+    else:
+        print(f"  Service owner (Master Safe): {master_safe_addr}")
+
+    # --- Step 2: Validate Master EOA -> Master Safe ---
+    print("\n--- Validating Master Safe ---")
+    master_safe = w3.eth.contract(address=master_safe_addr, abi=SAFE_ABI)
+    master_owners = master_safe.functions.getOwners().call()
+    master_threshold = master_safe.functions.getThreshold().call()
+    print(f"Master Safe owners: {master_owners}")
+    print(f"Master Safe threshold: {master_threshold}")
+
+    if master_eoa_address not in master_owners:
+        print(f"ERROR: Master EOA {master_eoa_address} is not an owner of Master Safe {master_safe_addr}")
+        sys.exit(1)
+
+    if master_threshold != 1:
+        print(f"ERROR: Master Safe threshold is {master_threshold}, but this script only supports threshold=1.")
+        print("  For threshold > 1, additional owner signatures are required.")
+        sys.exit(1)
+
+    # --- Step 3: Get operators (before any state changes) ---
+    # Must get operators while service is in Deployed state (agent instances are available)
+    operators = []
+    if service_state in (2, 3, 4, 5):  # ActiveRegistration, FinishedRegistration, Deployed, TerminatedBonded
+        operators = get_service_operators(service_registry, service_id)
+        if operators:
+            print(f"\nService operators: {operators}")
+
+    # --- Step 4: Unstake (if staked) ---
+    if is_staked:
+        print(f"\n--- Unstaking service {service_id} ---")
+        print(f"Master Safe -> stakingProxy.unstake({service_id})...")
+
+        unstake_data = encode_function_data(staking_contract.functions.unstake(service_id))
+
+        if impersonate_mode:
+            receipt = exec_safe_tx_impersonated(
+                w3, master_safe, master_eoa_address,
+                to=nft_holder, value=0, data=unstake_data, operation=CALL,
+            )
+        else:
+            receipt = exec_safe_tx(
+                w3, master_safe, account,
+                to=nft_holder, value=0, data=unstake_data, operation=CALL,
+            )
+
+        if receipt.status != 1:
+            print(f"ERROR: Unstake transaction failed. Receipt: {receipt}")
+            sys.exit(1)
+
+        # Verify NFT is now held by Master Safe
+        new_nft_holder = service_registry.functions.ownerOf(service_id).call()
+        if new_nft_holder != master_safe_addr:
+            print(f"ERROR: After unstake, NFT holder is {new_nft_holder}, expected {master_safe_addr}")
+            sys.exit(1)
+        print(f"Unstake successful. Service NFT now held by Master Safe.")
+
+        # Re-read service state after unstake
+        service_info = service_registry.functions.mapServices(service_id).call()
+        service_state = service_info[6]
+        state_name = SERVICE_STATE_NAMES.get(service_state, f"Unknown({service_state})")
+        print(f"Service state after unstake: {state_name} ({service_state})")
+
+    # --- Step 5: Terminate (if needed) ---
+    if service_state in (2, 3, 4):  # ActiveRegistration, FinishedRegistration, Deployed
+        print(f"\n--- Terminating service {service_id} ---")
+        print(f"Master Safe -> serviceManager.terminate({service_id})...")
+
+        terminate_data = encode_function_data(service_manager.functions.terminate(service_id))
+
+        if impersonate_mode:
+            receipt = exec_safe_tx_impersonated(
+                w3, master_safe, master_eoa_address,
+                to=service_manager.address, value=0, data=terminate_data, operation=CALL,
+            )
+        else:
+            receipt = exec_safe_tx(
+                w3, master_safe, account,
+                to=service_manager.address, value=0, data=terminate_data, operation=CALL,
+            )
+
+        if receipt.status != 1:
+            print(f"ERROR: Terminate transaction failed. Receipt: {receipt}")
+            sys.exit(1)
+
+        # Re-read service state
+        service_info = service_registry.functions.mapServices(service_id).call()
+        service_state = service_info[6]
+        state_name = SERVICE_STATE_NAMES.get(service_state, f"Unknown({service_state})")
+        print(f"Terminate successful. Service state: {state_name} ({service_state})")
+
+    # --- Step 6: Unbond (if needed) ---
+    if service_state == 5:  # TerminatedBonded
+        print(f"\n--- Unbonding service {service_id} ---")
+
+        if not operators:
+            # Try to get operators now (may fail if agent instances were already cleaned)
+            operators = get_service_operators(service_registry, service_id)
+
+        if not operators:
+            print("ERROR: Could not find any operators to unbond.")
+            print("  The service is in TerminatedBonded state but no operators were found.")
+            sys.exit(1)
+
+        for operator in operators:
+            operator = Web3.to_checksum_address(operator)
+            print(f"Unbonding operator {operator}...")
+
+            # ServiceManager.unbond(serviceId) uses msg.sender as the operator.
+            # So the operator itself must call ServiceManager.unbond.
+            if operator == master_safe_addr:
+                # Master Safe IS the operator — call via Master Safe -> ServiceManager.unbond
+                unbond_data = encode_function_data(service_manager.functions.unbond(service_id))
+
+                if impersonate_mode:
+                    receipt = exec_safe_tx_impersonated(
+                        w3, master_safe, master_eoa_address,
+                        to=service_manager.address, value=0, data=unbond_data, operation=CALL,
+                    )
+                else:
+                    receipt = exec_safe_tx(
+                        w3, master_safe, account,
+                        to=service_manager.address, value=0, data=unbond_data, operation=CALL,
+                    )
+            else:
+                # Operator is NOT Master Safe
+                if impersonate_mode:
+                    # On a fork, impersonate the operator directly
+                    print(f"  (impersonating operator {operator})")
+                    unbond_data = encode_function_data(service_manager.functions.unbond(service_id))
+                    unbond_data_hex = "0x" + unbond_data.hex()
+                    receipt = send_tx_impersonated(w3, operator, service_manager.address, unbond_data_hex)
+                else:
+                    print(f"ERROR: Operator {operator} is not Master Safe ({master_safe_addr}).")
+                    print("  Cannot unbond this operator without their private key.")
+                    print("  Options:")
+                    print("    1. Have the operator call serviceManager.unbond() directly")
+                    print("    2. Use unbondWithSignature() with the operator's signature")
+                    print("    3. Test on a fork with --impersonate to impersonate the operator")
+                    sys.exit(1)
+
+            if receipt.status != 1:
+                print(f"ERROR: Unbond transaction for operator {operator} failed. Receipt: {receipt}")
+                sys.exit(1)
+            print(f"  Operator {operator} unbonded successfully.")
+
+        # Re-read service state
+        service_info = service_registry.functions.mapServices(service_id).call()
+        service_state = service_info[6]
+        state_name = SERVICE_STATE_NAMES.get(service_state, f"Unknown({service_state})")
+        print(f"Service state after unbond: {state_name} ({service_state})")
+
+    # --- Step 7: Verify we're in PreRegistration ---
+    if service_state != 1:
+        state_name = SERVICE_STATE_NAMES.get(service_state, f"Unknown({service_state})")
+        print(f"ERROR: Service must be in PreRegistration state (1) for recovery, but is in {state_name} ({service_state}).")
+        sys.exit(1)
+
+    # --- Step 8: Recovery (if needed) ---
+    agent_safe = w3.eth.contract(address=Web3.to_checksum_address(agent_safe_addr), abi=SAFE_ABI)
+    agent_owners = agent_safe.functions.getOwners().call()
+    print(f"\nAgent Safe owners: {agent_owners}")
+
+    if not (len(agent_owners) == 1 and agent_owners[0] == master_safe_addr):
+        print("\n--- Recovering Agent Safe ownership ---")
+        print(f"Agent Safe owners are not [Master Safe]. Calling recoverAccess({service_id})...")
+
+        # Build recoverAccess calldata
+        recover_data = encode_function_data(recovery_module.functions.recoverAccess(service_id))
+
+        # Execute via Master Safe
+        if impersonate_mode:
+            receipt = exec_safe_tx_impersonated(
+                w3, master_safe, master_eoa_address,
+                to=recovery_module.address, value=0, data=recover_data, operation=CALL,
+            )
+        else:
+            receipt = exec_safe_tx(
+                w3, master_safe, account,
+                to=recovery_module.address, value=0, data=recover_data, operation=CALL,
+            )
+
+        if receipt.status != 1:
+            print(f"ERROR: Recovery transaction failed. Receipt: {receipt}")
+            sys.exit(1)
+
+        # Verify
+        agent_owners = agent_safe.functions.getOwners().call()
+        if not (len(agent_owners) == 1 and agent_owners[0] == master_safe_addr):
+            print(f"ERROR: Recovery succeeded on-chain but Agent Safe owners are {agent_owners}, expected [{master_safe_addr}]")
+            sys.exit(1)
+
+        print(f"Recovery successful. Agent Safe sole owner is now Master Safe.")
+    else:
+        print("Agent Safe sole owner is already Master Safe. Skipping recovery.")
+
+    # --- Step 9: Fund Recovery ---
+    print("\n--- Recovering funds ---")
+
+    # Fetch token config
+    erc20_tokens = fetch_token_config(args.chain_id)
+
+    # Check balances
+    transfers = []
+    recovered_summary = []
+
+    # Check ERC20 balances
+    for token_info in erc20_tokens:
+        token_addr = Web3.to_checksum_address(token_info["address"])
+        token = w3.eth.contract(address=token_addr, abi=ERC20_ABI)
+
+        try:
+            balance = token.functions.balanceOf(agent_safe_addr).call()
+        except Exception as e:
+            print(f"  WARNING: Failed to check balance for {token_info['symbol']} ({token_addr}): {e}")
+            continue
+
+        if balance > 0:
+            decimals = token_info["decimals"]
+            human_balance = balance / (10 ** decimals)
+            print(f"  {token_info['symbol']}: {human_balance} ({balance} wei)")
+
+            transfer_data = "0x" + encode_function_data(token.functions.transfer(master_safe_addr, balance)).hex()
+            transfers.append({
+                "to": token_addr,
+                "value": 0,
+                "data": transfer_data,
+                "operation": CALL,
+            })
+            recovered_summary.append(f"  {token_info['symbol']}: {human_balance}")
+
+    # Check native balance
+    native_balance = w3.eth.get_balance(agent_safe_addr)
+    if native_balance > 0:
+        human_native = native_balance / (10 ** 18)
+        print(f"  Native token: {human_native} ({native_balance} wei)")
+
+        # Transfer native tokens: send to Master Safe with empty data
+        transfers.append({
+            "to": master_safe_addr,
+            "value": native_balance,
+            "data": b"",
+            "operation": CALL,
+        })
+        recovered_summary.append(f"  Native: {human_native}")
+
+    if not transfers:
+        print("No tokens with non-zero balance found in Agent Safe. Nothing to recover.")
+        sys.exit(0)
+
+    # Build the Agent Safe multicall
+    print(f"\nBuilding multicall with {len(transfers)} transfer(s)...")
+
+    multisend_packed = encode_multisend_txs(transfers)
+    multisend_data_bytes = encode_function_data(multisend.functions.multiSend(multisend_packed))
+
+    # Build Agent Safe execTransaction calldata
+    # Master Safe is sole owner and will be msg.sender, so v=1 signature is valid
+    agent_safe_signature = build_safe_signature_for_approved_owner(master_safe_addr)
+
+    agent_exec_data_bytes = encode_function_data(agent_safe.functions.execTransaction(
+        multisend_addr,       # to: MultiSend
+        0,                    # value
+        multisend_data_bytes, # data
+        DELEGATECALL,         # operation
+        0, 0, 0,              # safeTxGas, baseGas, gasPrice
+        ZERO_ADDRESS,         # gasToken
+        ZERO_ADDRESS,         # refundReceiver
+        agent_safe_signature, # signatures (v=1 for Master Safe as sender)
+    ))
+
+    # Master EOA -> Master Safe -> Agent Safe.execTransaction(...)
+    print("Executing fund recovery transaction...")
+    if impersonate_mode:
+        receipt = exec_safe_tx_impersonated(
+            w3, master_safe, master_eoa_address,
+            to=agent_safe_addr, value=0, data=agent_exec_data_bytes, operation=CALL,
+        )
+    else:
+        receipt = exec_safe_tx(
+            w3, master_safe, account,
+            to=agent_safe_addr, value=0, data=agent_exec_data_bytes, operation=CALL,
+        )
+
+    if receipt.status != 1:
+        print(f"ERROR: Fund recovery transaction failed. Receipt status: {receipt.status}")
+        print(f"  Tx hash: {receipt.transactionHash.hex()}")
+        sys.exit(1)
+
+    # --- Step 10: Verify & Report ---
+    print(f"\nTransaction successful: {receipt.transactionHash.hex()}")
+    print("\n--- Verification ---")
+
+    all_clear = True
+    for token_info in erc20_tokens:
+        token_addr = Web3.to_checksum_address(token_info["address"])
+        token = w3.eth.contract(address=token_addr, abi=ERC20_ABI)
+        try:
+            remaining = token.functions.balanceOf(agent_safe_addr).call()
+            if remaining > 0:
+                print(f"  WARNING: {token_info['symbol']} still has balance: {remaining}")
+                all_clear = False
+        except Exception:
+            pass
+
+    remaining_native = w3.eth.get_balance(agent_safe_addr)
+    if remaining_native > 0:
+        print(f"  Note: Native token remaining: {remaining_native / 10**18} (expected small amount for gas)")
+
+    print("\n--- Recovery Summary ---")
+    print(f"Recovered from Agent Safe ({agent_safe_addr}) to Master Safe ({master_safe_addr}):")
+    for line in recovered_summary:
+        print(line)
+
+    if all_clear:
+        print("\nAll ERC20 funds recovered successfully.")
+    else:
+        print("\nWARNING: Some tokens may not have been fully recovered. Check balances.")
+
+
+if __name__ == "__main__":
+    main()

--- a/test/RecoverFunds.t.sol
+++ b/test/RecoverFunds.t.sol
@@ -1,0 +1,814 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {IService} from "../contracts/interfaces/IService.sol";
+import "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+import {GnosisSafeProxy} from "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxy.sol";
+import {GnosisSafeProxyFactory} from "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
+import {MultiSend} from "@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol";
+import {DefaultCallbackHandler} from "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
+import {Test} from "forge-std/Test.sol";
+import {Utils} from "./utils/Utils.sol";
+import {ERC20Token} from "../contracts/test/ERC20Token.sol";
+import {GnosisSafeMultisig} from "../contracts/multisigs/GnosisSafeMultisig.sol";
+import {SafeMultisigWithRecoveryModule} from "../contracts/multisigs/SafeMultisigWithRecoveryModule.sol";
+import {RecoveryModule} from "../contracts/multisigs/RecoveryModule.sol";
+import {ServiceRegistryL2} from "../contracts/ServiceRegistryL2.sol";
+import {ServiceRegistryTokenUtility} from "../contracts/ServiceRegistryTokenUtility.sol";
+import {ServiceManager} from "../contracts/ServiceManager.sol";
+import {ServiceManagerProxy} from "../contracts/ServiceManagerProxy.sol";
+import {MockIdentityRegistry} from "../contracts/test/MockIdentityRegistry.sol";
+import {IdentityRegistryBridger} from "../contracts/8004/IdentityRegistryBridger.sol";
+import {IdentityRegistryBridgerProxy} from "../contracts/8004/IdentityRegistryBridgerProxy.sol";
+import {StakingNativeToken} from "../contracts/staking/StakingNativeToken.sol";
+import {StakingBase, ServiceInfo} from "../contracts/staking/StakingBase.sol";
+import {StakingActivityChecker} from "../contracts/staking/StakingActivityChecker.sol";
+
+/// @title RecoverFundsTest - Tests the fund recovery flow matching the recover_funds.py script
+/// @notice This test reproduces the exact setup described in the recovery planning doc:
+///         Master EOA -> Master Safe -> RecoveryModule.recoverAccess() -> fund recovery via Agent Safe
+contract RecoverFundsTest is Test {
+    Utils internal utils;
+
+    // Contracts
+    ServiceRegistryL2 internal serviceRegistry;
+    ServiceRegistryTokenUtility internal serviceRegistryTokenUtility;
+    ServiceManager internal serviceManager;
+    GnosisSafe internal gnosisSafe;
+    GnosisSafeProxyFactory internal gnosisSafeProxyFactory;
+    GnosisSafeMultisig internal gnosisSafeMultisig;
+    SafeMultisigWithRecoveryModule internal safeMultisigWithRecoveryModule;
+    RecoveryModule internal recoveryModule;
+    MultiSend internal multiSend;
+    DefaultCallbackHandler internal defaultCallbackHandler;
+    ERC20Token internal tokenOLAS;
+    ERC20Token internal tokenUSDC;
+
+    // Addresses
+    address payable[] internal users;
+    address internal deployer;
+    address internal operator;
+    uint256 internal masterEOAPk;
+    address internal masterEOA;
+    address internal backupOwner;
+    address internal agentInstance;
+
+    // Master Safe and Agent Safe
+    GnosisSafe internal masterSafe;
+    GnosisSafe internal agentSafe;
+
+    // Service params
+    uint256 internal serviceId = 1;
+    uint32 internal threshold = 1;
+    uint96 internal regBond = 10 ether;
+    uint256 internal regDeposit = 10 ether;
+    bytes32 internal unitHash = 0x9999999999999999999999999999999999999999999999999999999999999999;
+    bytes internal payload;
+
+    function setUp() public {
+        utils = new Utils();
+        users = utils.createUsers(10);
+        deployer = users[0];
+        operator = users[1];
+        agentInstance = users[2];
+        backupOwner = users[3];
+
+        // Create master EOA with known private key
+        masterEOAPk = 0xA11CE;
+        masterEOA = vm.addr(masterEOAPk);
+        vm.deal(masterEOA, 100 ether);
+
+        // Deploy core contracts
+        serviceRegistry = new ServiceRegistryL2("Service Registry L2", "SERVICE", "https://localhost/service/");
+        serviceRegistryTokenUtility = new ServiceRegistryTokenUtility(address(serviceRegistry));
+
+        serviceManager = new ServiceManager(address(serviceRegistry), address(serviceRegistryTokenUtility));
+        bytes memory proxyData = abi.encodeWithSelector(serviceManager.initialize.selector, "");
+        ServiceManagerProxy serviceManagerProxy = new ServiceManagerProxy(address(serviceManager), proxyData);
+        serviceManager = ServiceManager(address(serviceManagerProxy));
+
+        serviceRegistry.changeManager(address(serviceManager));
+        serviceRegistryTokenUtility.changeManager(address(serviceManager));
+
+        // Deploy identity registry components (required by ServiceManager)
+        MockIdentityRegistry identityRegistry = new MockIdentityRegistry();
+        IdentityRegistryBridger identityRegistryBridger = new IdentityRegistryBridger(
+            address(identityRegistry), address(serviceRegistry)
+        );
+        proxyData = abi.encodeWithSelector(identityRegistryBridger.initialize.selector, "");
+        IdentityRegistryBridgerProxy identityRegistryBridgerProxy =
+            new IdentityRegistryBridgerProxy(address(identityRegistryBridger), proxyData);
+        identityRegistryBridger = IdentityRegistryBridger(address(identityRegistryBridgerProxy));
+        serviceManager.setIdentityRegistryBridger(address(identityRegistryBridger));
+
+        // Deploy Safe infrastructure
+        gnosisSafe = new GnosisSafe();
+        gnosisSafeProxyFactory = new GnosisSafeProxyFactory();
+        gnosisSafeMultisig = new GnosisSafeMultisig(payable(address(gnosisSafe)), address(gnosisSafeProxyFactory));
+        multiSend = new MultiSend();
+        defaultCallbackHandler = new DefaultCallbackHandler();
+
+        // Deploy recovery module
+        recoveryModule = new RecoveryModule(address(multiSend), address(serviceRegistry));
+
+        // Deploy SafeMultisigWithRecoveryModule (creates Safe with recovery module enabled)
+        safeMultisigWithRecoveryModule = new SafeMultisigWithRecoveryModule(
+            payable(address(gnosisSafe)), address(gnosisSafeProxyFactory), address(recoveryModule)
+        );
+
+        // Whitelist multisig implementations
+        serviceRegistry.changeMultisigPermission(address(safeMultisigWithRecoveryModule), true);
+
+        // Deploy ERC20 tokens
+        tokenOLAS = new ERC20Token();
+        tokenUSDC = new ERC20Token();
+
+        // --- Create Master Safe (with masterEOA + backupOwner, threshold=1) ---
+        address[] memory masterOwners = new address[](2);
+        masterOwners[0] = masterEOA;
+        masterOwners[1] = backupOwner;
+
+        bytes memory masterSetupData = abi.encodeWithSelector(
+            GnosisSafe.setup.selector,
+            masterOwners,       // owners
+            1,                  // threshold
+            address(0),         // to
+            "",                 // data
+            address(defaultCallbackHandler), // fallbackHandler
+            address(0),         // paymentToken
+            0,                  // payment
+            payable(address(0)) // paymentReceiver
+        );
+
+        GnosisSafeProxy masterSafeProxy = gnosisSafeProxyFactory.createProxyWithNonce(
+            address(gnosisSafe), masterSetupData, 0
+        );
+        masterSafe = GnosisSafe(payable(address(masterSafeProxy)));
+
+        // Verify Master Safe setup
+        assertEq(masterSafe.getThreshold(), 1);
+        address[] memory owners = masterSafe.getOwners();
+        assertEq(owners.length, 2);
+
+        // --- Create service owned by Master Safe ---
+        uint32[] memory agentIds = new uint32[](1);
+        agentIds[0] = 1;
+        IService.AgentParams[] memory agentParams = new IService.AgentParams[](1);
+        agentParams[0].slots = 1;
+        agentParams[0].bond = regBond;
+
+        // ServiceManager.create uses msg.sender as manager, so we call from deployer (who is the manager owner)
+        serviceManager.create(
+            address(masterSafe),                    // owner = Master Safe
+            serviceManager.ETH_TOKEN_ADDRESS(),     // token
+            unitHash,                               // configHash
+            agentIds,
+            agentParams,
+            threshold
+        );
+
+        // Verify service owner is Master Safe
+        assertEq(serviceRegistry.ownerOf(serviceId), address(masterSafe));
+
+        // --- Activate registration (Master Safe calls via Master EOA) ---
+        _execMasterSafeTx(
+            address(serviceManager),
+            regDeposit,
+            abi.encodeWithSelector(ServiceManager.activateRegistration.selector, serviceId)
+        );
+
+        // --- Register agent instance (operator) ---
+        address[] memory instances = new address[](1);
+        instances[0] = agentInstance;
+        vm.prank(operator);
+        serviceManager.registerAgents{value: regBond}(serviceId, instances, agentIds);
+
+        // --- Deploy service (Master Safe calls via Master EOA) ---
+        // This creates the Agent Safe with recovery module enabled
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(
+                ServiceManager.deploy.selector,
+                serviceId,
+                address(safeMultisigWithRecoveryModule),
+                payload
+            )
+        );
+
+        // Get the Agent Safe address
+        (, address multisig, , , , , ) = serviceRegistry.mapServices(serviceId);
+        agentSafe = GnosisSafe(payable(multisig));
+
+        // Verify Agent Safe is owned by agentInstance
+        address[] memory agentOwners = agentSafe.getOwners();
+        assertEq(agentOwners.length, 1);
+        assertEq(agentOwners[0], agentInstance);
+
+        // --- Fund Agent Safe with ERC20 tokens and native tokens ---
+        tokenOLAS.mint(address(agentSafe), 1000 ether);
+        tokenUSDC.mint(address(agentSafe), 5000 ether);
+        vm.deal(address(agentSafe), 2 ether);
+
+        // --- Terminate service (Master Safe calls via Master EOA) ---
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(ServiceManager.terminate.selector, serviceId)
+        );
+
+        // --- Unbond (operator) ---
+        vm.prank(operator);
+        serviceManager.unbond(serviceId);
+
+        // Verify service is in PreRegistration state (1)
+        (, , , , , , ServiceRegistryL2.ServiceState state) = serviceRegistry.mapServices(serviceId);
+        assertEq(uint8(state), 1); // PreRegistration
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: Execute a transaction on Master Safe signed by Master EOA
+    // -----------------------------------------------------------------------
+    function _execMasterSafeTx(address to, uint256 value, bytes memory data) internal {
+        _execSafeTxWithEOA(masterSafe, masterEOAPk, to, value, data, Enum.Operation.Call);
+    }
+
+    function _execSafeTxWithEOA(
+        GnosisSafe safe,
+        uint256 signerPk,
+        address to,
+        uint256 value,
+        bytes memory data,
+        Enum.Operation operation
+    ) internal {
+        uint256 nonce = safe.nonce();
+
+        bytes32 txHash = safe.getTransactionHash(
+            to, value, data, operation,
+            0, 0, 0,
+            address(0), payable(address(0)),
+            nonce
+        );
+
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(signerPk, txHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+
+        vm.prank(vm.addr(signerPk));
+        safe.execTransaction{value: value}(
+            to, value, data, operation,
+            0, 0, 0,
+            address(0), payable(address(0)),
+            signature
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: Build v=1 sender-approved signature for Safe owner
+    // -----------------------------------------------------------------------
+    function _buildApprovedOwnerSignature(address owner) internal pure returns (bytes memory) {
+        // r = owner address padded to 32 bytes, s = 0, v = 1
+        return abi.encodePacked(bytes12(0), owner, bytes32(0), uint8(1));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: Encode a single tx for MultiSend packed format
+    // -----------------------------------------------------------------------
+    function _encodeMultiSendTx(
+        Enum.Operation operation,
+        address to,
+        uint256 value,
+        bytes memory data
+    ) internal pure returns (bytes memory) {
+        return abi.encodePacked(uint8(operation), to, value, data.length, data);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: Full recovery flow matching recover_funds.py
+    // -----------------------------------------------------------------------
+    function test_recoverAccess_and_transferFunds() public {
+        // --- Step 1: Verify Agent Safe is NOT owned by Master Safe yet ---
+        address[] memory agentOwners = agentSafe.getOwners();
+        assertTrue(agentOwners.length != 1 || agentOwners[0] != address(masterSafe));
+
+        // --- Step 2: Recovery - Master EOA -> Master Safe -> recoverAccess(serviceId) ---
+        _execMasterSafeTx(
+            address(recoveryModule),
+            0,
+            abi.encodeWithSelector(RecoveryModule.recoverAccess.selector, serviceId)
+        );
+
+        // Verify Master Safe is now the sole owner of Agent Safe
+        agentOwners = agentSafe.getOwners();
+        assertEq(agentOwners.length, 1);
+        assertEq(agentOwners[0], address(masterSafe));
+        assertEq(agentSafe.getThreshold(), 1);
+
+        // --- Step 3: Build Agent Safe multicall to transfer all tokens ---
+        // Record balances before
+        uint256 olasBalance = tokenOLAS.balanceOf(address(agentSafe));
+        uint256 usdcBalance = tokenUSDC.balanceOf(address(agentSafe));
+        uint256 nativeBalance = address(agentSafe).balance;
+
+        assertGt(olasBalance, 0);
+        assertGt(usdcBalance, 0);
+        assertGt(nativeBalance, 0);
+
+        // Build individual transfer calldata
+        bytes memory olasTransfer = abi.encodeWithSelector(
+            bytes4(keccak256("transfer(address,uint256)")), address(masterSafe), olasBalance
+        );
+        bytes memory usdcTransfer = abi.encodeWithSelector(
+            bytes4(keccak256("transfer(address,uint256)")), address(masterSafe), usdcBalance
+        );
+
+        // Pack transfers into MultiSend format
+        bytes memory multiSendData = abi.encodePacked(
+            _encodeMultiSendTx(Enum.Operation.Call, address(tokenOLAS), 0, olasTransfer),
+            _encodeMultiSendTx(Enum.Operation.Call, address(tokenUSDC), 0, usdcTransfer),
+            _encodeMultiSendTx(Enum.Operation.Call, address(masterSafe), nativeBalance, "")
+        );
+
+        // Encode multiSend call
+        bytes memory agentSafeInnerData = abi.encodeWithSelector(
+            MultiSend.multiSend.selector, multiSendData
+        );
+
+        // --- Step 4: Build Agent Safe execTransaction with v=1 signature ---
+        // Master Safe is sole owner and will be msg.sender, so v=1 works
+        bytes memory masterSafeSignature = _buildApprovedOwnerSignature(address(masterSafe));
+
+        bytes memory agentExecData = abi.encodeWithSelector(
+            GnosisSafe.execTransaction.selector,
+            address(multiSend),      // to: MultiSend
+            uint256(0),              // value
+            agentSafeInnerData,      // data
+            Enum.Operation.DelegateCall, // operation
+            uint256(0),              // safeTxGas
+            uint256(0),              // baseGas
+            uint256(0),              // gasPrice
+            address(0),              // gasToken
+            payable(address(0)),     // refundReceiver
+            masterSafeSignature      // signatures
+        );
+
+        // --- Step 5: Master EOA -> Master Safe -> Agent Safe.execTransaction ---
+        _execMasterSafeTx(
+            address(agentSafe),
+            0,
+            agentExecData
+        );
+
+        // --- Step 6: Verify all funds transferred ---
+        assertEq(tokenOLAS.balanceOf(address(agentSafe)), 0);
+        assertEq(tokenUSDC.balanceOf(address(agentSafe)), 0);
+        assertEq(address(agentSafe).balance, 0);
+
+        // Verify Master Safe received funds
+        assertEq(tokenOLAS.balanceOf(address(masterSafe)), olasBalance);
+        assertEq(tokenUSDC.balanceOf(address(masterSafe)), usdcBalance);
+        assertGe(address(masterSafe).balance, nativeBalance);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: Recovery when Agent Safe already owned by Master Safe (skip recovery)
+    // -----------------------------------------------------------------------
+    function test_skipRecovery_whenAlreadyOwner() public {
+        // First recover
+        _execMasterSafeTx(
+            address(recoveryModule),
+            0,
+            abi.encodeWithSelector(RecoveryModule.recoverAccess.selector, serviceId)
+        );
+
+        // Verify Master Safe is sole owner
+        address[] memory agentOwners = agentSafe.getOwners();
+        assertEq(agentOwners.length, 1);
+        assertEq(agentOwners[0], address(masterSafe));
+
+        // Now do fund transfer (no recovery step needed)
+        uint256 olasBalance = tokenOLAS.balanceOf(address(agentSafe));
+        bytes memory olasTransfer = abi.encodeWithSelector(
+            bytes4(keccak256("transfer(address,uint256)")), address(masterSafe), olasBalance
+        );
+
+        bytes memory multiSendData = _encodeMultiSendTx(
+            Enum.Operation.Call, address(tokenOLAS), 0, olasTransfer
+        );
+
+        bytes memory agentSafeInnerData = abi.encodeWithSelector(
+            MultiSend.multiSend.selector, multiSendData
+        );
+
+        bytes memory masterSafeSignature = _buildApprovedOwnerSignature(address(masterSafe));
+
+        bytes memory agentExecData = abi.encodeWithSelector(
+            GnosisSafe.execTransaction.selector,
+            address(multiSend),
+            uint256(0),
+            agentSafeInnerData,
+            Enum.Operation.DelegateCall,
+            uint256(0),
+            uint256(0),
+            uint256(0),
+            address(0),
+            payable(address(0)),
+            masterSafeSignature
+        );
+
+        _execMasterSafeTx(address(agentSafe), 0, agentExecData);
+
+        assertEq(tokenOLAS.balanceOf(address(agentSafe)), 0);
+        assertEq(tokenOLAS.balanceOf(address(masterSafe)), olasBalance);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: Recovery with only native token (no ERC20s)
+    // -----------------------------------------------------------------------
+    function test_recoverNativeTokenOnly() public {
+        // Recover access
+        _execMasterSafeTx(
+            address(recoveryModule),
+            0,
+            abi.encodeWithSelector(RecoveryModule.recoverAccess.selector, serviceId)
+        );
+
+        uint256 nativeBalance = address(agentSafe).balance;
+        assertGt(nativeBalance, 0);
+
+        // Build a simple native transfer (no multiSend needed for single tx, but we use it
+        // to match the script pattern)
+        bytes memory multiSendData = _encodeMultiSendTx(
+            Enum.Operation.Call, address(masterSafe), nativeBalance, ""
+        );
+
+        bytes memory agentSafeInnerData = abi.encodeWithSelector(
+            MultiSend.multiSend.selector, multiSendData
+        );
+
+        bytes memory masterSafeSignature = _buildApprovedOwnerSignature(address(masterSafe));
+
+        bytes memory agentExecData = abi.encodeWithSelector(
+            GnosisSafe.execTransaction.selector,
+            address(multiSend),
+            uint256(0),
+            agentSafeInnerData,
+            Enum.Operation.DelegateCall,
+            uint256(0),
+            uint256(0),
+            uint256(0),
+            address(0),
+            payable(address(0)),
+            masterSafeSignature
+        );
+
+        uint256 masterSafeBalanceBefore = address(masterSafe).balance;
+
+        _execMasterSafeTx(address(agentSafe), 0, agentExecData);
+
+        assertEq(address(agentSafe).balance, 0);
+        assertEq(address(masterSafe).balance, masterSafeBalanceBefore + nativeBalance);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: Recovery with multiple agent instances
+    // -----------------------------------------------------------------------
+    function test_recoverAccess_multipleAgentInstances() public {
+        // Create a second service with 2 agent instances
+        address agentInstance2 = users[4];
+
+        uint32[] memory agentIds = new uint32[](1);
+        agentIds[0] = 1;
+        IService.AgentParams[] memory agentParams = new IService.AgentParams[](1);
+        agentParams[0].slots = 2;
+        agentParams[0].bond = regBond;
+
+        uint256 sid = 2;
+
+        serviceManager.create(
+            address(masterSafe),
+            serviceManager.ETH_TOKEN_ADDRESS(),
+            unitHash,
+            agentIds,
+            agentParams,
+            2  // threshold = 2
+        );
+
+        // Activate
+        _execMasterSafeTx(
+            address(serviceManager),
+            regDeposit,
+            abi.encodeWithSelector(ServiceManager.activateRegistration.selector, sid)
+        );
+
+        // Register 2 agent instances
+        address[] memory instances = new address[](2);
+        instances[0] = users[5];
+        instances[1] = agentInstance2;
+        uint32[] memory ids = new uint32[](2);
+        ids[0] = 1;
+        ids[1] = 1;
+        vm.prank(operator);
+        serviceManager.registerAgents{value: 2 * regBond}(sid, instances, ids);
+
+        // Deploy
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(
+                ServiceManager.deploy.selector,
+                sid,
+                address(safeMultisigWithRecoveryModule),
+                payload
+            )
+        );
+
+        // Get agent safe
+        (, address multisig2, , , , , ) = serviceRegistry.mapServices(sid);
+        GnosisSafe agentSafe2 = GnosisSafe(payable(multisig2));
+
+        // Verify 2 owners
+        address[] memory owners2 = agentSafe2.getOwners();
+        assertEq(owners2.length, 2);
+
+        // Fund it
+        tokenOLAS.mint(address(agentSafe2), 500 ether);
+        vm.deal(address(agentSafe2), 1 ether);
+
+        // Terminate and unbond
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(ServiceManager.terminate.selector, sid)
+        );
+        vm.prank(operator);
+        serviceManager.unbond(sid);
+
+        // Recovery
+        _execMasterSafeTx(
+            address(recoveryModule),
+            0,
+            abi.encodeWithSelector(RecoveryModule.recoverAccess.selector, sid)
+        );
+
+        // Verify sole owner
+        owners2 = agentSafe2.getOwners();
+        assertEq(owners2.length, 1);
+        assertEq(owners2[0], address(masterSafe));
+
+        // Transfer funds
+        uint256 olasBalance = tokenOLAS.balanceOf(address(agentSafe2));
+        uint256 nativeBalance = address(agentSafe2).balance;
+
+        bytes memory multiSendData = abi.encodePacked(
+            _encodeMultiSendTx(
+                Enum.Operation.Call,
+                address(tokenOLAS),
+                0,
+                abi.encodeWithSelector(bytes4(keccak256("transfer(address,uint256)")), address(masterSafe), olasBalance)
+            ),
+            _encodeMultiSendTx(Enum.Operation.Call, address(masterSafe), nativeBalance, "")
+        );
+
+        bytes memory agentSafeInnerData = abi.encodeWithSelector(
+            MultiSend.multiSend.selector, multiSendData
+        );
+
+        bytes memory sig = _buildApprovedOwnerSignature(address(masterSafe));
+
+        bytes memory agentExecData = abi.encodeWithSelector(
+            GnosisSafe.execTransaction.selector,
+            address(multiSend),
+            uint256(0),
+            agentSafeInnerData,
+            Enum.Operation.DelegateCall,
+            uint256(0),
+            uint256(0),
+            uint256(0),
+            address(0),
+            payable(address(0)),
+            sig
+        );
+
+        _execMasterSafeTx(address(agentSafe2), 0, agentExecData);
+
+        assertEq(tokenOLAS.balanceOf(address(agentSafe2)), 0);
+        assertEq(address(agentSafe2).balance, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: Create a service, deploy it, and return the Agent Safe
+    // -----------------------------------------------------------------------
+    function _createAndDeployService(uint256 sid, address agentInst) internal returns (GnosisSafe) {
+        uint32[] memory agentIds = new uint32[](1);
+        agentIds[0] = 1;
+        IService.AgentParams[] memory agentParams = new IService.AgentParams[](1);
+        agentParams[0].slots = 1;
+        agentParams[0].bond = regBond;
+
+        serviceManager.create(
+            address(masterSafe),
+            serviceManager.ETH_TOKEN_ADDRESS(),
+            unitHash,
+            agentIds,
+            agentParams,
+            threshold
+        );
+
+        _execMasterSafeTx(
+            address(serviceManager),
+            regDeposit,
+            abi.encodeWithSelector(ServiceManager.activateRegistration.selector, sid)
+        );
+
+        // Master Safe registers as operator
+        address[] memory instances = new address[](1);
+        instances[0] = agentInst;
+        uint32[] memory ids = new uint32[](1);
+        ids[0] = 1;
+        _execMasterSafeTx(
+            address(serviceManager),
+            regBond,
+            abi.encodeWithSelector(ServiceManager.registerAgents.selector, sid, instances, ids)
+        );
+
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(
+                ServiceManager.deploy.selector,
+                sid,
+                address(safeMultisigWithRecoveryModule),
+                payload
+            )
+        );
+
+        (, address multisig2, , , , , ) = serviceRegistry.mapServices(sid);
+        return GnosisSafe(payable(multisig2));
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: Deploy staking, stake a service, return staking contract address
+    // -----------------------------------------------------------------------
+    function _deployStakingAndStake(uint256 sid, address agentSafeAddr)
+        internal
+        returns (StakingNativeToken)
+    {
+        StakingActivityChecker activityChecker = new StakingActivityChecker(1e15);
+        bytes32 safeProxyHash = agentSafeAddr.codehash;
+
+        StakingBase.StakingParams memory stakingParams = StakingBase.StakingParams({
+            metadataHash: bytes32(uint256(1)),
+            maxNumServices: 10,
+            rewardsPerSecond: 1e15,
+            minStakingDeposit: 2,
+            minNumStakingPeriods: 10,
+            maxNumInactivityPeriods: 10,
+            livenessPeriod: 10,
+            timeForEmissions: 1000,
+            numAgentInstances: 1,
+            agentIds: new uint256[](0),
+            threshold: 0,
+            configHash: bytes32(0),
+            proxyHash: safeProxyHash,
+            serviceRegistry: address(serviceRegistry),
+            activityChecker: address(activityChecker)
+        });
+
+        StakingNativeToken snt = new StakingNativeToken();
+        snt.initialize(stakingParams);
+
+        // Fund staking contract with rewards
+        vm.deal(address(this), 100 ether);
+        (bool sent, ) = address(snt).call{value: 10 ether}("");
+        assertTrue(sent);
+
+        // Approve and stake
+        _execMasterSafeTx(
+            address(serviceRegistry),
+            0,
+            abi.encodeWithSelector(serviceRegistry.approve.selector, address(snt), sid)
+        );
+        _execMasterSafeTx(
+            address(snt),
+            0,
+            abi.encodeWithSelector(bytes4(keccak256("stake(uint256)")), sid)
+        );
+
+        return snt;
+    }
+
+    // -----------------------------------------------------------------------
+    // Helper: Build and execute fund transfer via MultiSend on recovered Agent Safe
+    // -----------------------------------------------------------------------
+    function _transferFundsFromAgentSafe(GnosisSafe targetAgentSafe) internal {
+        uint256 olasBalance = tokenOLAS.balanceOf(address(targetAgentSafe));
+        uint256 nativeBalance = address(targetAgentSafe).balance;
+
+        bytes memory multiSendData = abi.encodePacked(
+            _encodeMultiSendTx(
+                Enum.Operation.Call,
+                address(tokenOLAS),
+                0,
+                abi.encodeWithSelector(bytes4(keccak256("transfer(address,uint256)")), address(masterSafe), olasBalance)
+            ),
+            _encodeMultiSendTx(Enum.Operation.Call, address(masterSafe), nativeBalance, "")
+        );
+
+        bytes memory agentSafeInnerData = abi.encodeWithSelector(
+            MultiSend.multiSend.selector, multiSendData
+        );
+
+        bytes memory sig = _buildApprovedOwnerSignature(address(masterSafe));
+
+        bytes memory agentExecData = abi.encodeWithSelector(
+            GnosisSafe.execTransaction.selector,
+            address(multiSend),
+            uint256(0),
+            agentSafeInnerData,
+            Enum.Operation.DelegateCall,
+            uint256(0),
+            uint256(0),
+            uint256(0),
+            address(0),
+            payable(address(0)),
+            sig
+        );
+
+        _execMasterSafeTx(address(targetAgentSafe), 0, agentExecData);
+    }
+
+    // -----------------------------------------------------------------------
+    // Test: Full recovery from staked service
+    // Unstake -> Terminate -> Unbond -> Recover -> Transfer
+    // -----------------------------------------------------------------------
+    function test_recoverFromStakedService() public {
+        uint256 sid = 2;
+
+        // Create and deploy a new service with Master Safe as operator
+        GnosisSafe agentSafe2 = _createAndDeployService(sid, users[5]);
+
+        // Fund Agent Safe
+        tokenOLAS.mint(address(agentSafe2), 777 ether);
+        vm.deal(address(agentSafe2), 3 ether);
+
+        // Deploy staking and stake the service
+        StakingNativeToken stakingNativeToken = _deployStakingAndStake(sid, address(agentSafe2));
+
+        // Verify staking setup
+        assertEq(serviceRegistry.ownerOf(sid), address(stakingNativeToken));
+        ServiceInfo memory sInfo = stakingNativeToken.getServiceInfo(sid);
+        assertEq(sInfo.owner, address(masterSafe));
+
+        // --- Full recovery flow (matching recover_funds.py) ---
+
+        // Step 1: Unstake
+        vm.warp(block.timestamp + 101);
+        _execMasterSafeTx(
+            address(stakingNativeToken),
+            0,
+            abi.encodeWithSelector(bytes4(keccak256("unstake(uint256)")), sid)
+        );
+        assertEq(serviceRegistry.ownerOf(sid), address(masterSafe));
+
+        // Step 2: Terminate
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(ServiceManager.terminate.selector, sid)
+        );
+
+        // Step 3: Unbond (Master Safe is operator)
+        _execMasterSafeTx(
+            address(serviceManager),
+            0,
+            abi.encodeWithSelector(ServiceManager.unbond.selector, sid)
+        );
+
+        // Verify PreRegistration state
+        (, , , , , , ServiceRegistryL2.ServiceState state2) = serviceRegistry.mapServices(sid);
+        assertEq(uint8(state2), 1);
+
+        // Step 4: Recovery
+        _execMasterSafeTx(
+            address(recoveryModule),
+            0,
+            abi.encodeWithSelector(RecoveryModule.recoverAccess.selector, sid)
+        );
+
+        address[] memory owners2 = agentSafe2.getOwners();
+        assertEq(owners2.length, 1);
+        assertEq(owners2[0], address(masterSafe));
+
+        // Step 5: Transfer funds
+        uint256 olasBalanceBefore = tokenOLAS.balanceOf(address(agentSafe2));
+        assertEq(olasBalanceBefore, 777 ether);
+        assertGt(address(agentSafe2).balance, 0);
+
+        _transferFundsFromAgentSafe(agentSafe2);
+
+        // Verify all funds transferred
+        assertEq(tokenOLAS.balanceOf(address(agentSafe2)), 0);
+        assertEq(address(agentSafe2).balance, 0);
+        assertEq(tokenOLAS.balanceOf(address(masterSafe)), olasBalanceBefore);
+    }
+}


### PR DESCRIPTION
  Summary

  Implements a Python script and Forge tests for recovering funds from an Agent Safe when the Agent EOA private key has been lost. The script handles the full service lifecycle — from staked services all the way through to fund sweep — in a single automated run.

  Motivation

  When an agent instance's EOA key is lost, the Agent Safe (service multisig) becomes inaccessible through normal means. Funds locked in the Agent Safe (native tokens, OLAS,
  USDC, etc.) need to be recovered by the service owner (Master Safe) using the on-chain RecoveryModule.

  New Files

  - scripts/recover_funds_lost_agent_eoa.py — Python recovery script
  - test/RecoverFunds.t.sol — Forge test suite (5 tests)
  - docs/recover_funds_lost_agent_eoa.md — Detailed documentation with usage instructions, examples, and design explanation

  Modified Files

  - CLAUDE.md — Added Recovery Module section, development notes on POA middleware, Safe signature types, calldata encoding patterns

  How the Script Works

  The script auto-detects the Master Safe address and service state, then executes whichever steps are needed:

  1. Unstake — If the service NFT is held by a staking contract, calls stakingProxy.unstake(serviceId) via Master Safe
  2. Terminate — If the service is in Deployed/Active/FinishedRegistration state, calls serviceManager.terminate(serviceId) via Master Safe
  3. Unbond — If the service is in TerminatedBonded state, calls serviceManager.unbond(serviceId) for each operator
  4. Recover access — Calls recoveryModule.recoverAccess(serviceId) via Master Safe, making Master Safe the sole owner of Agent Safe
  5. Sweep funds — Builds a MultiSend multicall to transfer all ERC20 tokens + native balance from Agent Safe to Master Safe

  Staking detection: The script queries serviceRegistry.ownerOf(serviceId) and tries getServiceInfo(serviceId) on the NFT holder to detect whether the service is staked. The
  actual owner (Master Safe) is resolved from ServiceInfo.owner.

  Token list: ERC20 token addresses are fetched at runtime from the olas-operate-app token config, supporting Ethereum, Polygon, Gnosis, Base, Optimism, Arbitrum, Celo, and Mode.

  Signing modes:
  - Production: Master EOA signs via private key file or PRIVATE_KEY env var (ECDSA v=27/28)
  - Fork testing: --impersonate flag sends unsigned transactions on Tenderly/Anvil forks using Safe v=1 sender-approved signatures

  See docs/recover_funds_lost_agent_eoa.md for full documentation.