### PR TITLE
doc: convert vulnerabilities PDF to markdown and use relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,20 @@ a group of agent instances.
 
 In order to generalize `components` / `agents` / `services`, they are referred sometimes as `units`.
 
-A graphical overview is available [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/flowchart.md).
+A graphical overview is available [here](./docs/flowchart.md).
 
-For reference purposes only, an older version of the general Autonolas architecture is available [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/On-chain_architecture_v6.png).
+For reference purposes only, an older version of the general Autonolas architecture is available [here](./docs/On-chain_architecture_v6.png).
 
 An overview of the design, details on how securing services with ETH or a custom ERC20 token, how service owners can opt for a set of authorized operators,
-as well as how DAOs can manage their autonomous services are provided [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/AgentServicesFunctionality.pdf).
+as well as how DAOs can manage their autonomous services are provided [here](./docs/AgentServicesFunctionality.pdf).
 
 We have a core periphery architecture for both the components/agents and services. The core contracts are ERC721s primarily accessed via the peripheral manager contracts.
 
-An overview of the state machine governing service management and usage is provided [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/FSM.md).
+An overview of the state machine governing service management and usage is provided [here](./docs/FSM.md).
 
-A more detailed set of registries definitions are provided [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/definitions.md).
+A more detailed set of registries definitions are provided [here](./docs/definitions.md).
 
-An overview of the registries contracts related to staking can be found [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/StakingSmartContracts.pdf). Details on Olas staking are provided [here](https://staking.olas.network/poaa-whitepaper.pdf).
+An overview of the registries contracts related to staking can be found [here](./docs/StakingSmartContracts.pdf). Details on Olas staking are provided [here](https://staking.olas.network/poaa-whitepaper.pdf).
 
 Note that by default the contracts do not work with:
 - Fee on transfer tokens;
@@ -37,39 +37,39 @@ Note that by default the contracts do not work with:
 
 The following list represents registries contracts:
 - Abstract contracts:
-  - [GenericRegistry](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/GenericRegistry.sol)
-  - [UnitRegistry](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/UnitRegistry.sol)
-  - [GenericManager](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/GenericManager.sol)
-  - [StakingBase.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingBase.sol)
+  - [GenericRegistry](./contracts/GenericRegistry.sol)
+  - [UnitRegistry](./contracts/UnitRegistry.sol)
+  - [GenericManager](./contracts/GenericManager.sol)
+  - [StakingBase.sol](./contracts/staking/StakingBase.sol)
 - Core contracts:
-  - [AgentRegistry](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/AgentRegistry.sol)
-  - [ComponentRegistry](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/ComponentRegistry.sol)
-  - ServiceRegistry [L1](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/ServiceRegistry.sol)
-    [L2](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/ServiceRegistryL2.sol)
-  - [ServiceRegistryTokenUtility](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/ServiceRegistryTokenUtility.sol)
+  - [AgentRegistry](./contracts/AgentRegistry.sol)
+  - [ComponentRegistry](./contracts/ComponentRegistry.sol)
+  - ServiceRegistry [L1](./contracts/ServiceRegistry.sol)
+    [L2](./contracts/ServiceRegistryL2.sol)
+  - [ServiceRegistryTokenUtility](./contracts/ServiceRegistryTokenUtility.sol)
 - Periphery contracts:
-  - [RegistriesManager](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/RegistriesManager.sol)
-  - [ServiceManager](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/ServiceManager.sol)
+  - [RegistriesManager](./contracts/RegistriesManager.sol)
+  - [ServiceManager](./contracts/ServiceManager.sol)
 - Utility contracts:
-  - [OperatorSignedHashes](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/utils/OperatorSignedHashes.sol)
-  - [OperatorWhitelist](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/utils/OperatorWhitelist.sol)
+  - [OperatorSignedHashes](./contracts/utils/OperatorSignedHashes.sol)
+  - [OperatorWhitelist](./contracts/utils/OperatorWhitelist.sol)
 
 - Staking related contracts:
-  - [StakingBase.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingBase.sol)
-  - [StakingNativeToken.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingNativeToken.sol)
-  - [StakingToken.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingToken.sol)
-  - [StakingFactory.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingFactory.sol)
-  - [StakingProxy.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingProxy.sol)
-  - [StakingVerifier.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingVerifier.sol)
-  - [StakingActivityChecker.sol](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/staking/StakingActivityChecker.sol)
+  - [StakingBase.sol](./contracts/staking/StakingBase.sol)
+  - [StakingNativeToken.sol](./contracts/staking/StakingNativeToken.sol)
+  - [StakingToken.sol](./contracts/staking/StakingToken.sol)
+  - [StakingFactory.sol](./contracts/staking/StakingFactory.sol)
+  - [StakingProxy.sol](./contracts/staking/StakingProxy.sol)
+  - [StakingVerifier.sol](./contracts/staking/StakingVerifier.sol)
+  - [StakingActivityChecker.sol](./contracts/staking/StakingActivityChecker.sol)
 
 
 In order to deploy a service, its registered agent instances form a consensus mechanism via the means of multisigs using the generic multisig interface.
 One of the most well-known multisigs is [Safe](https://safe.global/). The Safe interface implementation of a generic multisig interface is provided here:
-- [GnosisSafeMultisig](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/multisigs/GnosisSafeMultisig.sol)
+- [GnosisSafeMultisig](./contracts/multisigs/GnosisSafeMultisig.sol)
 
 The updated version accounting for the Recovery Module installation is provided here:
-- [SafeMultisigWithRecoveryModule](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/multisigs/SafeMultisigWithRecoveryModule.sol)
+- [SafeMultisigWithRecoveryModule](./contracts/multisigs/SafeMultisigWithRecoveryModule.sol)
 
 Another multisig implementation allows to upgrade / downgrade the number of agent instances that govern the same Safe multisig instance between different service re-deployments.
 Please note that the initial multisig instance must already exist from a previous service deployment.
@@ -77,13 +77,13 @@ In order to use that option, registered agent instances forming a consensus are 
 Then, the service owner must terminate the service, update the number of desired agent instances and move it into a new `active-registration` state.
 Once all agent instances are registered, the service owner re-deploys the service by giving up their ownership of the multisig with registered agent instances and by setting a new multisig instance threshold.
 The implementation of such multisig is provided here:
-- [GnosisSafeSameAddressMultisig](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/multisigs/GnosisSafeSameAddressMultisig.sol)
+- [GnosisSafeSameAddressMultisig](./contracts/multisigs/GnosisSafeSameAddressMultisig.sol)
 
 The updated version with the access recovery feature is provided in the Recovery Module contract itself here:
-- [RecoveryModule](https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/multisigs/RecoveryModule.sol)
+- [RecoveryModule](./contracts/multisigs/RecoveryModule.sol)
 
 To verify the multisig data when redeploying the service using the GnosisSafeSameAddressMultisig contract while changing service multisig owners (with updated agent instance addresses),
-see the guidelines and corresponding scripts [here](https://github.com/valory-xyz/autonolas-registries/blob/main/scripts/multisig/)
+see the guidelines and corresponding scripts [here](./scripts/multisig/)
 
 As more multisigs come into play, their underlying implementation of the generic multisig will be added.
 
@@ -142,7 +142,7 @@ forge test -f $FORK_NODE_URL --match-contract StakePolySafe -vvv
 ```
 
 ### Test with instrumented code
-[Scribble](https://docs.scribble.codes/) annotated contracts are located in https://github.com/valory-xyz/autonolas-registries/blob/main/contracts/scribble.
+[Scribble](https://docs.scribble.codes/) annotated contracts are located in ./contracts/scribble.
 
 Install Scribble in order to instrument the code:
 ```
@@ -183,18 +183,18 @@ several steps in order to be verified. Those include:
 
 ## Deployment
 The deployment of contracts to the test- and main-net is split into step-by-step series of scripts for more control and checkpoint convenience.
-The description of deployment procedure can be found here: [deployment](https://github.com/valory-xyz/autonolas-registries/blob/main/scripts/deployment).
+The description of deployment procedure can be found here: [deployment](./scripts/deployment).
 
-The finalized contract ABIs for deployment and their number of optimization passes are located here: [ABIs](https://github.com/valory-xyz/autonolas-registries/blob/main/abis).
+The finalized contract ABIs for deployment and their number of optimization passes are located here: [ABIs](./abis).
 Each folder there contains contracts compiled with the solidity version before their deployment.
 
-For testing purposes, the hardhat node deployment script is located [here](https://github.com/valory-xyz/autonolas-registries/blob/main/deploy).
+For testing purposes, the hardhat node deployment script is located [here](./deploy).
 
-If you want to use custom contracts in the registry image, read [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/running_with_custom_contracts.md).
+If you want to use custom contracts in the registry image, read [here](./docs/running_with_custom_contracts.md).
 
 ### Audits
-- The audit is provided as development matures. The latest audit report can be found here: [audits](https://github.com/valory-xyz/autonolas-registries/blob/main/audits).
-- A list of known vulnerabilities can be found here: [Vulnerabilities list](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/Vulnerabilities_list_registries.pdf)
+- The audit is provided as development matures. The latest audit report can be found here: [audits](./audits).
+- A list of known vulnerabilities can be found here: [Vulnerabilities list](./docs/Vulnerabilities_list_registries.md)
 
 #### Static audit
 The static audit checks all the deployed contracts on-chain info correctness and can be run using the following script:
@@ -203,7 +203,7 @@ node scripts/audit_chains/audit_contracts_setup.js
 ```
 
 ## Deployed Protocol
-The list of contract addresses for different chains and their full contract configuration can be found [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/configuration.json).
+The list of contract addresses for different chains and their full contract configuration can be found [here](./docs/configuration.json).
 
 In order to test the protocol setup on all the deployed chains, the audit script is implemented. Make sure to export
 required API keys for corresponding chains (see the script for more information). The audit script can be run as follows:
@@ -212,7 +212,7 @@ node scripts/audit_chains/audit_contracts_setup.js
 ```
 
 ### Mainnet snapshot of registries
-In order to get the current snapshot of all the registries, the following script is provided [here](https://github.com/valory-xyz/autonolas-registries/blob/main/scripts/mainnet_snapshot.js).
+In order to get the current snapshot of all the registries, the following script is provided [here](./scripts/mainnet_snapshot.js).
 The script can be run with the following command:
 ```
 npx hardhat run scripts/mainnet_snapshot.js --network mainnet
@@ -223,12 +223,12 @@ NOTE: whilst the snapshot does maintain the exact dependency structure between c
 
 ## Protocol-owned-services
 A specific service can be owned by a DAO-governed protocol. In order to construct a DAO proposal for the service (re-)deployment,
-the following step-by-step guide is advised to be observed [here](https://github.com/valory-xyz/autonolas-registries/blob/main/docs/DAO_service_deloyment_FSM.pdf).
+the following step-by-step guide is advised to be observed [here](./docs/DAO_service_deloyment_FSM.pdf).
 
 ## Integrations on non-EVM blockchains
 ### Solana
 The light protocol with a similar functionality to ServiceRegistryL2 is implemented as part of the Solana integration network.
-The ServiceRegistrySolana program is developed [here](https://github.com/valory-xyz/autonolas-registries/blob/main/integrations/solana).
+The ServiceRegistrySolana program is developed [here](./integrations/solana).
 
 
 ## Acknowledgements

--- a/audits/internal14/README.md
+++ b/audits/internal14/README.md
@@ -13,7 +13,7 @@ N/A
 ```
 sol2uml storage contracts/ -f png -c ServiceManager -o audits/internal14/ServiceManager.png
 ```
-[ServiceManager](https://github.com/valory-xyz/autonolas-registries/blob/main/audits/internal14/ServiceManager.png)
+[ServiceManager](./ServiceManager.png)
 
 ### Coverage
 ```

--- a/docs/Vulnerabilities_list_registries.md
+++ b/docs/Vulnerabilities_list_registries.md
@@ -1,0 +1,692 @@
+# Contracts vulnerabilities
+
+## Vulnerabilities list
+
+- [Involved contracts and level of the bugs](#involved-contracts-and-level-of-the-bugs)
+- [Vulnerabilities](#vulnerabilities)
+    - [1. tokenURI function](#1-tokenuri-function)
+    - [2. create function](#2-create-function)
+    - [3. update function (zero bonds)](#3-update-function-zero-bonds)
+    - [4. update function (replacing agent Ids)](#4-update-function-replacing-agent-ids)
+    - [5. drain function](#5-drain-function)
+    - [6. _checkTokenStakingDeposit function](#6-_checktokenstakingdeposit-function)
+    - [7. _isRatio function](#7-_isratio-function)
+    - [8. stake function](#8-stake-function)
+    - [9. unstake function](#9-unstake-function)
+    - [10. checkpoint function: O(n) complexity due to gas overflow](#10-checkpoint-function-on-complexity-and-dos-due-to-gas-overflow)
+    - [11. deploy function](#11-deploy-function)
+    - [12. create function](#12-create-function-1)
+    - [13. _claim function](#13-_claim-function)
+    - [14. execTransaction return value in RecoveryModule and other multisig creating contracts](#14-exectransaction-return-value-in-recoverymodule-and-other-multisig-creating-contracts)
+    - [15. registerAgentsWithSignature operator whitelist bypass](#15-registeragentswithsignature-operator-whitelist-bypass)
+    - [16. registerAgentsWithSignature missing msg.value validation](#16-registeragentswithsignature-missing-msgvalue-validation)
+    - [17. slash mechanism abuse by service owner](#17-slash-mechanism-abuse-by-service-owner)
+    - [18. registerAgentsWithSignature missing deadline and maximum bond parameters](#18-registeragentswithsignature-missing-deadline-and-maximum-bond-parameters)
+    - [19. registerAgents agent instance registration DoS](#19-registeragents-agent-instance-registration-dos)
+    - [20. slash and proportional RewardDistributionType split](#20-slash-and-proportional-rewarddistributiontype-split)
+    - [21. checkpoint function during absence of rewards](#21-checkpoint-function-during-absence-of-rewards)
+    - [22. _withdraw function reentrancy in StakingBase](#22-_withdraw-function-reentrancy-in-stakingbase)
+    - [23. Custom reward distributor returning staking contract address](#23-custom-reward-distributor-returning-staking-contract-address)
+    - [24. Custom reward distributor code existence check](#24-custom-reward-distributor-code-existence-check)
+    - [25. calculateStakingLastReward rounding dust](#25-calculatestakinglastreward-rounding-dust)
+    - [26. Token callback reentrancy path across staking/service flows](#26-token-callback-reentrancy-path-across-stakingservice-flows)
+
+## Involved contracts and level of the bugs
+
+The present document aims to point out some vulnerabilities in the [autonolas-registry](https://github.com/valory-xyz/autonolas-registries)
+contracts.
+
+## Vulnerabilities
+
+### 1. `tokenURI` function
+
+**Severity**: Low
+
+The following function is implemented in the GenericRegistry contract:
+
+```solidity
+function tokenURI(uint256 unitId) public view virtual override returns (string memory)
+```
+
+This function is defined by the [EIP-721 standard](https://eips.ethereum.org/EIPS/eip-721). The standard states that the function is
+supposed to throw if `unitId` is not a valid NFT. However, in our contract, the function does
+not revert if the `unitId` is out of bounds, but just returns the value of a string with the
+defined prefix and 64 zeros derived from a zero bytes32 value.
+
+Therefore, we recommend checking the return value of this view function, and if the last
+64 symbols are zero, consider it to be an invalid NFT. Also one might use the `exists()`
+function to preliminary check if the requested NFT Id exists.
+
+### 2. `create` function
+
+**Severity**: Low
+
+The following function is implemented in the GnosisSafeMultisig contract:
+
+```solidity
+function create(address[] memory owners, uint256 threshold, bytes memory data) external returns (address multisig)
+```
+
+This function creates a Safe service multisig when the service is deployed. Since
+Autonolas protocol follows an optimistic design, none of the fields for the Safe multisig
+creation are restricted. This way, the service owner might pass the *payload* field as they
+feel fit for the purposes of the service multisig. That said, any possible malicious behavior
+can also be embedded in the *payload* value.
+
+In the event of the intended malicious multisig creation, the Autonolas protocol is not
+affected, however, accounts interacting with the corresponding service might bear
+eventual consequences of such a setup.
+
+We strongly recommend not abusing the *payload* field of the service multisig when
+deploying the service to perform any malicious actions.
+
+### 3. `update` function (zero bonds)
+
+**Severity**: Low
+
+The following function is implemented in the ServiceRegistry and ServiceRegistryL2
+contracts:
+
+```solidity
+function update(address serviceOwner, bytes32 configHash, uint32[] memory agentIds, uint32 threshold, uint256 serviceId) external returns (bool success)
+```
+
+This function allows updating a service in a *pre-registration* state in a CRUD way. E.g. if
+there is a need to remove `agentIds[i]` from the canonical agents making up the
+service, then it is sufficient to call this function and update it in such a way that a
+corresponding slots field is set to zero, i.e., `agentParam[i].slots=0`, also adjusting
+the `threshold`.
+
+When an agent slot is non-zero, and an operator can register an agent instance for that
+slot, it is necessary that the corresponding agent bond is non-zero. In the current
+implementation, there is no check for agent bonds to be different from zero if the
+corresponding agent slot is non-zero. This vulnerability would enable an operator to
+register an agent instance without the corresponding security bond. Hence, the operator
+would not be affected by any possible slashing condition if the total operator bond is
+equal to zero.
+
+This vulnerability is addressed for the ServiceRegistry contract and ServiceRegistryL2 by
+adding the zero-value check on the service manager level. Specifically, [serviceManager](../contracts/ServiceManagerToken.sol)
+contract handles the [check](../contracts/ServiceManagerToken.sol#L120) before calling the original serviceRegistry's update() method.
+See ../test/ServiceManagerToken.js#L326-L333C25
+for a test proving that the issue is resolved.
+
+In absence of redeploying a new manager for the ServiceRegistryL2 contract on other
+chains, we recommend that service owners assign a zero-value to agent bonds only if the
+corresponding agent slot is zero.
+
+### 4. `update` function (replacing agent Ids)
+
+**Severity**: Low
+
+The following function is implemented in the ServiceRegistry and ServiceRegistryL2
+contract:
+
+```solidity
+function update(address serviceOwner, bytes32 configHash, uint32[] memory agentIds, uint32 threshold, uint256 serviceId) external returns (bool success)
+```
+
+As described earlier, this function allows updating a service in a *pre-registration* state in a
+CRUD way. However, considering that there is no possible direct damage to the protocol
+and to save on transaction gas costs, the function is implemented via an optimistic
+approach.
+
+Specifically, the service owner might not specify that some of the *agent Ids* of the
+previous setup must be taken out of the system (by setting corresponding *slots* variable
+to zero). This means that operators are able to register agent instances specifying
+non-declared service agent Ids (as those were deliberately left in the corresponding map
+from the previous setup). This might lead to deploying the service on *agent Ids* from the
+previous setup, declaring that they actually run on current ones (as retrieved via the
+*getService()* view function).
+
+We strongly recommend not abusing the *update()* function in order to deploy the service
+to perform any malicious actions by using undeclared *agent Ids*, since this behavior is
+easily spotted off-chain.
+
+### 5. `drain` function
+
+**Severity**: Informative
+
+The following function is implemented in the ServiceRegistryTokenUtility contract:
+
+```solidity
+function drain(address token) external returns (uint256 amount)
+```
+
+The primary purpose of this function is to allow the removal of slashed tokens, other than
+chain-native tokens, from the contract.
+
+By design, in the current setup of the Treasury contract, there is currently no mechanism
+in place to facilitate the removal of tokens other than ETH that have not been added to the
+Treasury through the treasury `depositTokenForOLAS()` method. Therefore, we strongly
+advise against assigning the drainer role to the Treasury contract for
+ServiceRegistryTokenUtility contract deployed on Ethereum.
+
+### 6. `_checkTokenStakingDeposit` function
+
+**Severity**: Informative
+
+The following function is implemented in the ServiceRegistryTokenUtility contract:
+
+```solidity
+function _checkTokenStakingDeposit(uint256 serviceId, uint256 stakingDeposit, uint32[] memory) internal view virtual
+```
+
+The primary purpose of this function is to ensure that the service owner's security
+deposit and the operator bonds are correctly configured. Specifically, it checks that the
+service owner's security deposit (*securityDeposit*) and the *bond* for each operator are
+greater than or equal to *minStakingDeposit*. Given that *securityDeposit* is defined as the
+maximum among the operator bonds (max(*bond*)), when *minStakingDeposit* equals
+*securityDeposit*, the following relationship holds:
+
+*minStakingDeposit = securityDeposit >= bond >= minStakingDeposit*
+
+This ensures that *securityDeposit = minStakingDeposit = bond* for each operator bond.
+It's important to note that the service registry and service registry utility tokens do not
+enforce this requirement at the service level.
+
+If one attempts to stake a service with a *securityDeposit* equal to *minStakingDeposit* and
+operator bonds that differ (e.g., *bond[i] > bond[j]*), it is recommended to terminate and
+update the service configuration to ensure compatibility with the staking logic.
+
+### 7. `_isRatio` function
+
+**Severity**: Informative
+
+The following function is implemented in the StakingActivityChecker contract:
+
+```solidity
+function isRatioPass(uint256[] memory curNonces, uint256[] memory lastNonces, uint256 ts)
+```
+
+This function checks if the service multisig liveness ratio meets the defined threshold.
+The provided implementation serves as an illustrative example, and we highlight that
+multisig nonces are not tamper-resistant (cf. [InternalAudit4](../docs/internal_audit_4.pdf) for more details on this). It is
+therefore recommended to extend the basic `isRatioPass()` functionality in the
+StakingActivityChecker to verify whether specific on-chain actions occur within
+designated time frames. For a tamper-resistant check on on-chain activity, you can
+consider the one implemented in MechActivityChecker.sol in this [repository](https://github.com/valory-xyz/ai-registry-mech).
+
+Additionally, the protocol optimistically assumes that the StakingActivityChecker contract
+used for deploying staking instances is implemented with a correct logic. Therefore,
+unless unexpected behavior such as reverts or non-boolean returns occur, the contract's
+results will be considered accurate. However, this optimistic assumption can be exploited
+by malicious users. For instance, malicious users could deploy multiple contracts with
+flawed activity checks that always return true. They could then vote for these contracts,
+causing the OLAS amount to be distributed to all stakers, including those without activity.
+Conversely, malicious users could deploy contracts with incorrect liveness checks that
+always return false, leading to a situation where the OLAS amount is sent, but funds
+remain stuck in the staking contracts and cannot be recovered.
+
+The following measures can be considered to mitigate eventual abuses:
+1. Set a Sensible Threshold: The DAO needs to establish a sensible threshold to
+   enable staking emissions.
+2. On-Chain Blacklist: Implement an on-chain blacklist that can be updated through
+   governance votes, allowing the community to monitor and exclude malicious
+   contracts.
+3. Off-Chain Reputation System: Consider using an off-chain reputation system,
+   possibly leveraging oracles, to assess the trustworthiness of contracts.
+
+### 8. `stake` function
+
+**Severity**: Informative
+
+The following function is implemented in the StakingFactory contract:
+
+```solidity
+function stake(uint256 serviceId) external
+```
+
+The function stakes a specified service. However, if the service was evicted, it cannot be
+staked again until it is explicitly unstaked.
+
+### 9. `unstake` function
+
+**Severity**: Informative
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function unstake(uint256 serviceId) external returns (uint256 reward)
+```
+
+The function unstakes a previously staked service. If there are no available rewards left
+on a staking contract, the service can be unstaked immediately at any time. However, if
+there are even small funds deposited on the staking contract, the service will not be
+unstaked. It is not considered to be a griefing attack, since the unstake time is
+pre-defined via a `minStakingDuration` parameter. After that time, the service is
+unstaked without any concern of zero or non-zero available rewards. When the service is
+staked, it implicitly agrees to be staked for at least the `minStakingDuration`.
+
+### 10. `checkpoint` function: O(n) complexity and DoS due to gas overflow
+
+**Severity**: High
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function checkpoint() external returns (uint256[] memory, uint256[] memory, uint256[] memory, uint256[] memory)
+```
+
+The function goes through all currently staked services and checks for their activity KPIs.
+As designed, the function is O(n) in its complexity, where n is the number of staked
+services. The actual staking limit is 500 services per staking contract. With the recent
+Fusaka EVM upgrade being adopted, the hard cap on transaction gas limit is imposed.
+Governance action to limit staking number of slots takes roughly a week. During this time,
+if a staking contract is misconfigured and has more than 100 slots, there is a risk that
+having more number of services staked results in a failure of a checkpoint transaction.
+This scenario ultimately leads to all services being staked indefinitely. In time of waiting
+for the proposal properly limiting the number of staking contract services, launchers of
+staking contracts are urged to configure them with no more than 100 of staking slots.
+
+### 11. `deploy` function
+
+**Severity**: Informational
+
+The following function is implemented in the ServiceRegistry and ServiceRegistryL2
+contracts:
+
+```solidity
+function deploy(address serviceOwner, uint256 serviceId, address multisigImplementation, bytes memory data) external returns (address multisig)
+```
+
+This function is responsible for deploying a service by creating a multisig instance
+controlled by the set of service agent instances. When the deployment uses a
+`RecoveryModule`-enabled multisig implementation, an additional module is installed to
+allow the service multisig to recover ownership in the event that agent instance keys are
+accidentally lost.
+
+While this recovery mechanism allows re-obtaining control over the service multisig at the
+protocol level, it does not guarantee recoverability for all downstream integrations.
+In particular, certain interactions may still rely on the original multisig owner keys rather than
+the recovered ownership state.
+
+A notable example is the PolySafe (Gnosis Safe L2) integration used by Polymarket. In this
+context, if the original multisig owner key is lost, there is no supported mechanism to
+regain effective control over the multisig from Polymarket's perspective, even if
+ownership is recovered on-chain via the recovery module. As a consequence, critical
+operations such as:
+
+- buying or selling conditional tokens
+- future earning Polymarket liquidity rewards
+
+may become permanently inaccessible.
+
+Therefore, although the recovery module provides resilience against agent key loss at the
+service level, it does not fully mitigate the risk of loss of functionality for external systems
+that bind permissions to the original multisig owner keys.
+
+### 12. `create` function
+
+**Severity**: Low
+
+The following function is implemented in the PolySafeCreatorWithRecoveryModule
+contract:
+
+```solidity
+function create(address[] memory owners, uint256 threshold, bytes memory data) external returns (address multisig)
+```
+
+This function creates PolySafe multisig when deploying the service. Since the `data`
+payload in this function consists of signatures, there is a possibility to front-run this
+transaction, and the original transaction will fail.
+
+There is no financial benefit of such an attack. However, if this unlikely event takes place
+and in order not to set up a separate service, users are advised to engage with the
+GnosisSafeSameAddressMultisig contract's `create()` function specific for PolySafes.
+This contract function call just sets the already created multisig (that was created by front
+running), and service deployment is successful.
+
+### 13. `_claim` function
+
+**Severity**: Low
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function _claim(uint256 serviceId, bool execCheckPoint) internal returns (uint256 reward)
+```
+
+This function claims accumulated rewards for a specified `serviceId`. It also supports
+calling a `checkpoint()` function before claiming rewards. However, the sequence of
+actions is not entirely correct. The service reward is obtained first, then a checkpoint is
+called, and verification for the non-zero reward is made on a value obtained before the
+checkpoint. This leads to scenarios where there was no reward before the checkpoint,
+and thus the function reverts.
+
+In order to get a correct sequence of actions and avoid described scenarios, we
+recommend calling `checkpoint()` separately before calling the `claim()` function.
+
+### 14. `execTransaction` return value in RecoveryModule and other multisig creating contracts
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-69)
+
+The following issue affects the RecoveryModule and multisig creation contracts:
+
+The following function is implemented RecoveryModule contract:
+
+```solidity
+function recoverAccess(uint256 serviceId) external
+```
+
+The following function is implemented in the majority of multisig creating contracts in
+contracts/multisigs folder:
+
+```solidity
+function create(address[] memory owners, uint256 threshold, bytes memory data) external returns (address multisig)
+```
+
+Those functions utilize Safe's execTransaction calls and must revert if they return false on
+failure. The current implementation ignores this return value, allowing recovery attempts
+or multisig creation to silently fail.
+
+It is straightforward to perform the off-chain check for the recovery module. As for other
+multisig creating contracts invoked via the create() function during service deployment,
+the guard is enforced at the ServiceManager level (see PR #241).
+
+### 15. `registerAgentsWithSignature` operator whitelist bypass
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-149)
+
+The following function is implemented in the ServiceManager contract:
+
+```solidity
+function registerAgentsWithSignature(address serviceOwner, uint256 serviceId, address[] memory agentInstances, uint32[] memory agentIds, uint256 deadline, bytes memory signature) external payable
+```
+
+This issue reports that non-whitelisted operators could potentially register agents via
+registerAgentsWithSignature when the service owner has an operator whitelist enabled.
+This bypass could allow unauthorized operators to bind agent instances to a service.
+
+This is solely based on service owner responsibility and we don't expect any misbehavior
+against self. The service owner is the party that configures the whitelist and controls
+registration. An operator exploiting this would require the service owner to have provided
+or approved the signature in the first place.
+
+### 16. `registerAgentsWithSignature` missing msg.value validation
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-1175)
+
+The following function is implemented in the ServiceManager contract:
+
+```solidity
+function registerAgentsWithSignature(address serviceOwner, uint256 serviceId, address[] memory agentInstances, uint32[] memory agentIds, uint256 deadline, bytes memory signature) external payable
+```
+
+In registerAgents(), the native-token branch strictly enforces: `require(msg.value == agentInstances.length * BOND_WRAPPER)`. However, in registerAgentsWithSignature(),
+the function forwards `{value: agentInstances.length * BOND_WRAPPER}` to the registry
+without validating the caller-supplied msg.value.
+
+If msg.value exceeds the required bond wrapper amount, the excess ETH is not refunded
+and remains permanently stored in the ServiceManager contract, as no refund or
+withdrawal mechanism exists. This does not enable theft or privilege escalation. However,
+it introduces a locked ETH risk, where users may unintentionally overpay and permanently
+lose funds.
+
+This is not an exploitable vulnerability but represents improper input validation that can
+result in permanent ETH lock. The registerAgentsWithSignature() function needs to be
+corrected by adding the specified msg.value check. Note: One of the duplicate
+submissions (#S-1175) was assessed as out of scope per the Known Issues section
+regarding misconfigured registration from users.
+
+### 17. `slash` mechanism abuse by service owner
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-430)
+
+The following function is implemented in the ServiceRegistry and ServiceRegistryL2
+contracts:
+
+```solidity
+function slash(address[] memory agentInstances, uint96[] memory amounts, uint256 serviceId) external returns (bool success)
+```
+
+This issue affects the interaction between service owners, the multisig module system,
+and the ServiceRegistry slash mechanism.
+
+The protocol is permissionless, and thus the decision to engage in a specific service is
+solely on the service owner and operators. There are several ways to install any number
+of modules while the service owner is the owner of the multisig. It cannot be defined
+which modules to check on. Verifying this off-chain is much easier and free of charge.
+
+However, even if operators are slashed, the funds are locked on the ServiceRegistry
+contract itself, and could only be drained by the DAO. At that point the DAO will reimburse
+operators. This attack does not have any economical benefit for the service owner.
+
+### 18. `registerAgentsWithSignature` missing deadline and maximum bond parameters
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submissions #S-858, #S-862)
+
+The following function is implemented in the ServiceManager contract:
+
+```solidity
+function registerAgentsWithSignature(address serviceOwner, uint256 serviceId, address[] memory agentInstances, uint32[] memory agentIds, uint256 deadline, bytes memory signature) external payable
+```
+
+The operator can always set token approval to zero, and thus even with a valid signature
+the register function is going to fail. However, there could be a scenario where an
+operator is required to register to another service owner and once again provides
+approval to the ServiceRegistryTokenUtility. Then, the previous service owner can utilize
+the non-expiring signature to front-run and perform registration and utilize the newly
+provided approval, despite the approval being zero previously.
+
+As for the maximum bond signature, there are no deadlines for a signature provided by
+the operator to the service owner. If a user has a higher approval and/or different token
+approval in the future, a delayed registration via registerAgentsWithSignature could
+possibly affect operators.
+
+### 19. `registerAgents` agent instance registration DoS
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-901)
+
+This issue affects the agent instance registration logic in ServiceRegistry.
+
+```solidity
+function registerAgents(address operator, uint256 serviceId, address[] memory agentInstances, uint32[] memory agentIds) external payable
+```
+
+An agent instance is just an address that can be swapped with an infinite number of
+others. However, this is a legitimate issue, because the DoS can be sustained at a very
+cheap rate considering service creation is permissionless. Although it is technically true
+that an agent instance can be repeatedly swapped, the same argument also applies
+where a malicious user can theoretically infinitely DoS an agent registration.
+
+Medium severity was proposed but low is appropriate here considering this behavior is
+likely not incentivized due to gas costs. Ultimately this is not an issue for the protocol at
+all due to the unlimited number of addresses. Trying to control or whitelist all of them is
+something blockchain was not created for.
+
+### 20. `slash` and proportional `RewardDistributionType` split
+
+**Severity**: Informative
+**Source**: Code4rena 2026-01 Olas audit (submission #S-885)
+
+The following function is implemented in the ServiceRegistry and ServiceRegistryL2
+contracts:
+
+```solidity
+function slash(address[] memory agentInstances, uint96[] memory amounts, uint256 serviceId) external returns (bool success)
+```
+
+It allows service multisig to slash operator bonds for misbehaving agent instances.
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function _claim(uint256 serviceId, bool execCheckPoint) internal returns (uint256 reward)
+```
+
+This function claims accumulated rewards for a specified `serviceId`. If proportional
+reward type is selected for the staking contract, each operator is assigned an equal
+portion of the reward, under the assumption that each has deposited the same bond
+amount.
+
+However, some of the operator bonds could be slashed. It is reported that slashing must
+be taken into consideration. The mitigation step would include the change of
+`_getRewardReceiversAndAmounts()` function so that when the distribution type is
+Proportional, the function queries the actual bond amounts for each operator. Operators
+with reduced or zero bonds (due to slashing) should receive proportionally less or no
+rewards. This ensures accurate and fair distribution.
+
+At the same time, slashing is done for the agent instance misbehaving, and slashed funds
+are withheld by the protocol, specifically by the ServiceRegistry(L2) contracts. If an agent
+instance continues to perform its staking routines - those need to be rewarded for
+accordingly. Thus it is not considered to be an issue for the protocol, and the fix is not
+required.
+
+### 21. `checkpoint` function during absence of rewards
+
+**Severity**: Informative
+**Source**: Code4rena 2026-01 Olas audit (submission #S-763)
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function checkpoint() external returns (uint256[] memory, uint256[] memory, uint256[] memory, uint256[] memory)
+```
+
+The function goes through all currently staked services and checks for their activity KPIs.
+A time manipulation vulnerability allows inactive services to earn rewards for periods they
+provided no service. When `availableRewards` is zero, checkpoint operations are
+skipped, creating unmeasured time gaps that services can exploit by becoming active
+only when rewards become available again.
+
+It is recommended to separate the check of activity from reward distribution by
+maintaining activity state regardless of reward availability. However, the protocol
+maintains staking rewards, and if cancelled, no such situation is possible. Also, these
+actions could be prevented by ensuring at least wei levels of tokens within the staking
+contracts, which is easy to do considering reward deposits are permissionless.
+
+### 22. `_withdraw` function reentrancy in StakingBase
+
+**Severity**: Low
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function _withdraw(uint256 serviceId, uint256 reward) internal
+```
+
+This internal function is called by claim(), checkpointAndClaim(), and unstake() to distribute
+rewards to receivers. It reads balance into a local variable, loops through receivers calling
+_transfer() for each, then writes balance back to storage after all transfers complete.
+
+The developer comment at line 564 states: "reentrancy is not possible since reward is set to
+zero" -- this is true for same-service reentrancy, since mapServiceInfo[serviceId].reward is
+zeroed before _withdraw() is called. Re-entering claim() for the same service would find zero
+reward and revert.
+
+However, for StakingNativeToken, _transfer() sends ETH via .call{value} which gives the
+receiver a callback. A contract owning two services (A and B) on the same StakingNativeToken
+instance can exploit cross-service reentrancy:
+
+1. claim(serviceA) -> _withdraw -> _transfer sends ETH -> receive() callback
+2. In callback: claim(serviceB) -> _withdraw -> reads stale balance -> writes balance
+3. Outer _withdraw writes its stale balance -> overwrites the inner update
+
+This desynchronizes the balance variable from actual contract holdings. For StakingToken
+(ERC20), SafeTransferLib.safeTransfer is used, which does not give the receiver a callback, so
+reentrancy is not possible.
+
+Current deployment status:
+- StakingNativeToken is not utilized on any of supported chains
+- Only StakingToken (ERC20, no callback) contracts are in production
+
+The severity is Low (latent) as the code bug is confirmed but not currently exploitable. It would
+become Medium/High if StakingNativeToken is actively used with multiple services having a
+contract as reward receiver.
+
+We recommend adding a reentrancy guard (`_locked`) to StakingBase claim(), unstake(),
+forcedUnstake(), checkpoint(), and checkpointAndClaim().
+
+### 23. Custom reward distributor returning staking contract address
+
+**Severity**: Low
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function _getRewardReceiversAndAmounts(uint256 serviceId, uint256 reward) internal view returns (address[] memory receivers, uint256[] memory amounts)
+```
+
+When RewardDistributionType.Custom is selected, this function calls the external distributor
+contract via staticcall to obtain reward receivers and amounts. The validation checks (line
+720-733) verify that sum(amounts) == reward and that the arrays are non-empty, but do not
+check whether any receiver is address(this) (the staking contract itself).
+
+If a staker sets a custom distributor that returns the staking contract as a reward receiver,
+_withdraw() transfers tokens to address(this):
+
+- StakingToken: ERC20 transfer to self succeeds, tokens stay in the contract but balance
+  accounting desynchronizes (tracked balance < actual balance).
+- StakingNativeToken: ETH sent to self triggers receive() which increments balance and
+  availableRewards, then _withdraw overwrites balance with a stale value.
+
+The impact is self-inflicted: the staker loses their own reward. Tokens become permanently
+orphaned in the contract as there is no drain or rescue function. Other stakers are not directly
+affected since their rewards are calculated from availableRewards which decrements correctly.
+
+We recommend adding a check in the _getRewardReceiversAndAmounts Custom path to reject
+address(this) and address(0) as receivers.
+
+### 24. Custom reward distributor code existence check
+
+**Severity**: Low
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function _stake(uint256 serviceId, address serviceOwner, uint256[] memory serviceAgentIds) internal
+```
+
+When RewardDistributionType.Custom is selected during staking, the function validates only
+that the distributor address is not address(0) (line 824-827). It does not check code.length > 0.
+
+If an EOA or a not-yet-deployed contract is set as the custom distributor, the service's claim()
+will revert due to empty return data from the staticcall to the EOA. This effectively bricks the
+service's reward claims until unstake() or forcedUnstake() is called.
+
+The impact is self-inflicted: the service owner bricks their own claims. Other stakers are
+unaffected since claim is per-service and not batched.
+
+We recommend adding require(customDistributorAddr.code.length > 0) in the stake function
+when the Custom distribution type is used.
+
+### 25. `calculateStakingLastReward` rounding dust
+
+**Severity**: Informative
+
+The following function is implemented in the StakingBase contract:
+
+```solidity
+function calculateStakingLastReward(uint256 serviceId) external view returns (uint256 reward)
+```
+
+The checkpoint() function distributes rounding dust (up to numServices - 1 wei) to the service at
+index 0 in the staked services set (line 1002-1004). However, the calculateStakingLastReward()
+view function (line 1146) does not account for this bonus when computing the expected reward.
+
+The impact is cosmetic: the view function shows a slightly lower reward than what is actually
+distributed during the checkpoint. The discrepancy is at most numServices - 1 wei, which is
+negligible in practice.
+
+No fix is required, but callers of calculateStakingLastReward() should be aware that the actual
+reward for the first staked service may be marginally higher than reported.
+
+### 26. Token callback reentrancy path across staking/service flows
+
+**Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-1187)
+**Status**: Partially fixed. ServiceManager guarded (see https://github.com/valory-xyz/autonolas-registries/commit/7674c5c9); StakingBase locations unchanged.
+
+This issue reports a broader token callback reentrancy path that spans across staking and
+service flows. While the ServiceManager portion has been guarded with a reentrancy lock,
+StakingBase locations where similar callback-driven reentrancy could occur remain unchanged.
+The residual risk overlaps with the `_withdraw` reentrancy described in item 22, and carries
+the same deployment-context caveat: only StakingToken (ERC20) contracts are in production,
+so the callback vector is not currently exploitable.

--- a/docs/Vulnerabilities_list_registries.md
+++ b/docs/Vulnerabilities_list_registries.md
@@ -565,6 +565,7 @@ contracts, which is easy to do considering reward deposits are permissionless.
 ### 22. `_withdraw` function reentrancy in StakingBase
 
 **Severity**: Low
+**Source**: Code4rena 2026-01 Olas audit (submission #S-229)
 
 The following function is implemented in the StakingBase contract:
 


### PR DESCRIPTION
## Summary
- Convert `docs/Vulnerabilities_list_registries.pdf` to `docs/Vulnerabilities_list_registries.md`
- Add missing audit finding S-1187 (partially fixed token callback reentrancy)
- Remove fully fixed finding S-578 (only unaddressed issues are documented)
- Replace absolute GitHub `blob/main` URLs with relative paths in `README.md`, `docs/Vulnerabilities_list_registries.md`, and `audits/internal14/README.md`

## Test plan
- [ ] Verify all relative links resolve correctly on GitHub
- [ ] Verify vulnerabilities list content matches the original PDF