### PR TITLE
feat: SafeAndDepositWalletCreator for Polymarket CLOB v2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,9 +67,14 @@ forge test --match-contract Staking -vvv
 # Run PolySafeCreator tests
 forge test --match-contract PolySafeCreator -vvv
 
+# Run SafeAndDepositWalletCreator unit tests
+forge test --match-contract SafeAndDepositWalletCreator -vvv
+
 # Run fork tests (requires FORK_NODE_URL env var)
 forge test -f $FORK_NODE_URL --match-contract IdentityRegistry -vvv
 forge test -f $FORK_NODE_URL --match-contract StakePolySafe -vvv
+forge test -f $FORK_NODE_URL --match-contract SafeAndDepositWalletCreatorFork -vvv
+forge test -f $FORK_NODE_URL --match-contract SafeAndDepositWalletCreatorE2E -vvv
 ```
 
 ### Coverage
@@ -174,8 +179,13 @@ Services are deployed as multisigs. Multiple implementations are supported via t
 - `SafeMultisigWithRecoveryModule`: Includes Recovery Module for access recovery
 - `RecoveryModule`: Provides recovery functionality for Safe multisigs
 - `PolySafeCreatorWithRecoveryModule`: Creates Safe multisigs with recovery on Polygon/other chains
+- `SafeAndDepositWalletCreator`: Creates a Safe multisig with Recovery Module and links it to a Polymarket deposit wallet (Polygon-specific). The Safe is the OLAS service multisig + ERC-8004 agent wallet; the deposit wallet is a separate per-service Polymarket trading account, deployed out-of-band by Polymarket's relayer with the agent-instance EOA as its sole owner. The two are independent peers bridged by the agent EOA — the Safe cannot own the deposit wallet because Polymarket's `_erc1271IsValidSignatureNowCalldata` is pure ECDSA. See `clob_v2_deposit_wallet_creator_plan.md` for the full design.
 
 Multisig policies are tracked in `mapMultisigs` mapping in ServiceRegistry.
+
+### Polymarket CLOB v2 — deposit-wallet flow
+
+Under the CLOB v2 rollout (2026-05-01), new accounts must use deposit wallets to trade on Polymarket; new PolySafes are off-allowlist at the CLOB API ingest service. `SafeAndDepositWalletCreator` is the migration path: a single on-chain user transaction (`ServiceManager.deploy(serviceId, creator, data)`) deploys the Safe with RecoveryModule enabled atomically and verifies a pre-deployed deposit wallet, while off-chain HTTP calls to Polymarket's relayer (which is the only caller authorized to deploy deposit wallets — `DepositWalletFactory.deploy` is `onlyOperator`) handle the wallet provisioning and the post-deploy session-signer + approvals batch (`factory.proxy`). ERC-8004 `setAgentWallet` works through the Safe via the standard `SignMessageLib` + `CompatibilityFallbackHandler` path — no special multisig logic required, the Safe just needs the `CompatibilityFallbackHandler` set as its fallback (passed in via `data` to the creator). The end-to-end flow is exercised by `test/SafeAndDepositWalletCreatorFork.sol::SafeAndDepositWalletCreatorE2E`.
 
 ### Staking Contracts
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,11 @@ The implementation of such multisig is provided here:
 The updated version with the access recovery feature is provided in the Recovery Module contract itself here:
 - [RecoveryModule](./contracts/multisigs/RecoveryModule.sol)
 
+A Polymarket-specific multisig creator that pairs a Safe (OLAS service multisig + ERC-8004 agent wallet) with a Polymarket deposit wallet — required for new accounts under the CLOB v2 rollout — is provided here:
+- [SafeAndDepositWalletCreator](./contracts/multisigs/SafeAndDepositWalletCreator.sol)
+
+It produces the Safe with `RecoveryModule` enabled atomically (via `Safe.setup`) and verifies a deposit wallet that is pre-deployed out-of-band by Polymarket's relayer (the `DepositWalletFactory.deploy` entry point is operator-gated, so the deposit wallet must be provisioned via an off-chain HTTP call before the on-chain `serviceManager.deploy` is submitted). The Safe and the deposit wallet are independent peers bridged by the agent-instance EOA: the EOA is one of the Safe's owners and the deposit wallet's sole EOA owner. ERC-8004 `setAgentWallet` works through the Safe via the standard `SignMessageLib` + `CompatibilityFallbackHandler` path. See [`clob_v2_deposit_wallet_creator_plan.md`](./clob_v2_deposit_wallet_creator_plan.md) for the full architecture and threat model.
+
 To verify the multisig data when redeploying the service using the GnosisSafeSameAddressMultisig contract while changing service multisig owners (with updated agent instance addresses),
 see the guidelines and corresponding scripts [here](./scripts/multisig/)
 
@@ -134,11 +139,14 @@ Run tests with Forge (skip fork testing):
 ```
 forge test --match-contract Staking -vvv
 forge test --match-contract PolySafeCreator -vvv
+forge test --match-contract SafeAndDepositWalletCreator -vvv
 ```
 Run fork tests with Forge:
 ```
 forge test -f $FORK_NODE_URL --match-contract IdentityRegistry -vvv
 forge test -f $FORK_NODE_URL --match-contract StakePolySafe -vvv
+forge test -f $FORK_NODE_URL --match-contract SafeAndDepositWalletCreatorFork -vvv
+forge test -f $FORK_NODE_URL --match-contract SafeAndDepositWalletCreatorE2E -vvv
 ```
 
 ### Test with instrumented code

--- a/clob_v2_deposit_wallet_creator_plan.md
+++ b/clob_v2_deposit_wallet_creator_plan.md
@@ -1,7 +1,7 @@
 # Polymarket Deposit-Wallet — Multisig Creator Contract Plan
 
-**Date:** 2026-05-02 (initial); 2026-05-04 (probe correction — see §"Probe results")
-**Status:** Analysis only, no code changes proposed yet.
+**Date:** 2026-05-02 (initial); 2026-05-04 (probe correction — see §"Probe results"); 2026-05-09 (fresh code-side re-verification — see §"Re-verification 2026-05-09"); 2026-05-10 (design lock-in — see §"Design lock-in 2026-05-10")
+**Status:** Design locked-in to corrected Design C (Option B). Two prior load-bearing caveats (DW recovery weakness, front-running) explicitly accepted by the product team. Implementation ready to scope.
 **⚠️ READER NOTE:** Sections below pre-2026-05-04 assume a "Safe wraps DepositWallet by being its owner" topology. **That topology was invalidated by the 2026-05-04 source probe** — the DepositWallet's `isValidSignature` does plain ECDSA recovery against the owner, so the owner must be an EOA, not a Safe. See §"Probe results — 2026-05-04 — major design correction" immediately below for the corrected topology. The detailed sections that follow (Design B in depth, Design C, Recommended design) are preserved for historical context but their core "Safe-as-DW-owner" assumption is wrong; read them after the Probe results section.
 **Companion to:** `clob_v2_impact_polySafeCreator.md` (impact on existing
 PolySafeCreator) and `../wildcard/CLOB_V2_FOLLOWUPS.md` (full architecture
@@ -1826,6 +1826,79 @@ shape — both models are 1-of-1 at the trading layer.
 custom two-step EIP-712-signed handover, distinct from solady's standard).
 The standard solady Ownable is also kept for reference at
 `/tmp/poly-probe/Ownable-solady.sol` to show the diff.
+
+### Re-verification 2026-05-09 — fresh code-side probe of CTFExchange v2 + DW stack + SDKs (no reliance on prior FOLLOWUPS entries)
+
+Triggered by an "are these claims still accurate?" check. Re-fetched everything from primary sources today; all DW-stack findings hold; the CLOB exchange contract is verified as the place where the partner-channel rejection cannot live.
+
+**On-chain CTFExchange v2 (`0xE111…996B`) and NegRiskCTFExchange v2 (`0xe222…0F59`) — load-bearing for "what enforces the partner-channel allowlist?".** Solidity sources are byte-identical (only `constructor-args.txt` and `creator-tx-hash.txt` differ). GitHub head still `ccc0596074` (2026-04-13 — 26 days unchanged). Critical:
+
+- `Trading.sol::_validateOrder` (lines 46-63) does three checks total: non-zero `makerAmount`, valid signature, maker-not-paused. **No wallet-type gating, no allowlist lookup, no creation-time check.**
+- `Signatures.sol::_isValidSignature` accepts all four sigTypes (EOA / POLY_GNOSIS_SAFE / POLY_1271 / POLY_PROXY) unconditionally. `_verifyPolySafeSignature` only checks ECDSA + CREATE2-derived safe address.
+- **No allowlist storage of any kind anywhere in the deployed bytecode.** Exhaustive grep over `mixins/`, `libraries/`, `interfaces/` returns only `Auth.sol`'s admin/operator maps and `UserPausable`'s pause map. No `mapping(address=>bool) allowedTraders`, no `authorizedSigners`, no per-wallet policy.
+- Admin functions (`pauseTrading`, `setUserPauseBlockInterval`, `setFeeReceiver`, `setMaxFeeRate`) cannot disable a sigType or maintain a per-wallet allowlist.
+
+**Conclusion:** the rejection of new PolySafes from CLOB trading (per 2026-05-08 partner statement) is **provably enforced exclusively off-chain at Polymarket's CLOB API ingest service.** No on-chain layer could implement it without a contract upgrade, and no such upgrade has been deployed or even committed to the public repo. This *strengthens* — not weakens — Reading B: the partner statement is fully consistent with on-chain reality, and on-chain reality forecloses any alternative interpretation.
+
+**DepositWallet stack re-verified (Sourcify full-match today):**
+- `DepositWalletFactory.deploy()`/`proxy()` `onlyOperator` — re-confirmed lines 192/214. No meta-tx variant in ABI. Path 2 permanently off the table (re-confirmed against bytecode-verified source, not just commit history).
+- `DepositWallet._erc1271IsValidSignatureNowCalldata` pure ECDSA with literal comment `// always ECDSA, regardless of signer.code.length` — re-confirmed lines 442-451. Safe-as-DW-owner remains structurally sealed.
+- `DepositWallet.execute()` `onlyFactory` — re-confirmed line 172.
+
+**Public-doc delta (relevant to plan).** `/trading/deposit-wallet-migration` (last-modified 2026-05-02 per Mintlify metadata) is now stronger than prior FOLLOWUPS sweeps captured. Verbatim implementation checklist: *"Use deposit wallets only for new API users in this phase. Keep existing proxy and Safe users on their current signature type."* — explicit prescription, not just permission. Public-doc-vs-partner-channel gap is narrower than the 2026-05-08 sweep concluded; the substantive policy is now in public docs even though the "allowlist"/"grandfather" mechanism vocabulary remains partner-channel-exclusive. `/api-reference/authentication` (last-modified 2026-04-28 — predates rollout) still recommends sigType=2 for new users — confirmed real docs bug, not stale-cache illusion.
+
+**Implication for this plan.**
+
+1. **Reading B is now triple-anchored** — partner channel (2026-05-08), public docs (2026-05-02), and on-chain code structure (rejection cannot be on-chain → must be the CLOB API service the partner named). The 2026-05-04 plan's "Reading A remains the cleanest escape" caveat is materially weaker today; the smoke test would confirm rather than potentially refute.
+2. **The plan's contract design is fully validated against fresh source.** No on-chain claim in this doc has shifted under re-verification.
+3. **Build trigger threshold lowered.** Previously: build on confirmed Reading B *plus* product greenlight to commit to the relayer dependency. Now: same threshold, but the "is Reading B real?" component has triple confirmation. The remaining gate is product-side (accept relayer hard-dependency + accept self-custody-from-minute-zero loss).
+
+**Source artifact:** all on-chain findings cross-recorded in `../wildcard/CLOB_V2_FOLLOWUPS.md` §"2026-05-09 sweep — fresh code/docs/SDK re-verification" with full reconciliation table (claim ↔ public-doc ↔ partner-channel ↔ on-chain code).
+
+### Design lock-in 2026-05-10
+
+Confirmed with product team: implementation will follow the **corrected Design C** (a.k.a. Option B from the 2026-05-10 design discussion). Same as §"Recommended design — Design C in detail" except for the post-probe ownership correction:
+
+```solidity
+// Step 6 of create() — corrected post-probe ownership check:
+require(IDepositWallet(depositWalletAddr).owner() == agentInstances[0]);
+//                                                    ^^^^^^^^^^^^^^^^^^
+//        NOT == newSafe (pre-probe Design C had this; the EOA-only DW
+//        owner constraint forecloses Safe-as-DW-owner).
+```
+
+The contract surface, `data` payload shape, off-chain pre-flow (Pearl predicts addresses → relayer pre-deploys DW in parallel with OLAS service registration), and on-chain link-record (`mapMultisigDepositWallets` + `DepositWalletLinked` event) are unchanged from §"Recommended design — Design C in detail". The `READER NOTE` at the top of this plan still applies — read §"Probe results — 2026-05-04" and §"Corrected design — Safe + DepositWallet as independent peers" for the load-bearing topology, not the original Design C lines 850-1006.
+
+**On-chain footprint:** **exactly 1 user transaction** (`ServiceManager.deploy` → `safeAndDWCreator.create()`). Off-chain HTTP roundtrips are unconstrained — Pearl can fire any number of relayer calls before/after. The "1 tx" property is what matters; HTTP count is not a constraint.
+
+**Two prior load-bearing caveats explicitly accepted by product:**
+
+1. **DW recovery weakness defused by Privy custody.** The 2026-05-04 plan flagged "lose agent EOA → DW funds stranded" as the load-bearing risk and proposed a "sweep DW balance regularly" mitigation. Under Privy's key custody for the agent-instance EOA, the EOA isn't losable in the normal sense (Privy handles MPC/social recovery on the user-experience side). RecoveryModule still recovers the Safe (governance + ERC-8004 agent wallet status) for the OLAS-side via the existing `recover_funds_lost_agent_eoa.py` flow; Privy handles the DW-owner-EOA side. **No DW-side recovery sweep mitigation needed.** The "sweep regularly" line item from the plan can be dropped.
+
+2. **Front-running acknowledged but not a blocker.** The CREATE2 collision-revert in `LibClone.deployDeterministicERC1967` (one-owner-one-DW-ever) plus the agent-instance EOA being a Pearl-internal value (not user-visible / not contention-prone) keep the surface small. Document in the vuln-list for completeness — no on-chain countermeasure required beyond the factory's existing collision behaviour.
+
+**What stays load-bearing (unchanged):**
+
+- `DepositWalletFactory.deploy()` is `onlyOperator` → DW pre-deploy is HTTP-blocking. If Polymarket's relayer is down at the moment Pearl's user submits the on-chain tx, `create()` reverts on the `code.length > 0` check. Pearl must surface "deploy retry needed" UX. Unavoidable structural cost of the rollout.
+- Phase 4 (session-signer auth + approvals) is `onlyFactory`-gated → cannot be inlined. Trading-ready lags service-deployed by one relayer roundtrip (~5-30s). Worth surfacing in Pearl UX.
+- `agentInstance` is one of the Safe's owners *and* the DW's sole owner. Asymmetric topology — **not** "Safe owns DW" (which the source forecloses). Worth documenting in the contract NatSpec so future readers don't assume the wrong shape.
+- Whitelisting the new creator in `ServiceRegistryL2.mapMultisigs` via `changeMultisigPermission` requires a governance proposal — same shape as past creator additions.
+
+**Implementation scoping (rough):**
+
+- New contract: `contracts/multisigs/SafeAndDepositWalletCreator.sol` (or similar — naming TBD). Fork of `SafeMultisigWithRecoveryModule.sol` plus the DW-link verification (~60-80 LoC delta). New immutables: `depositWalletFactory`, `depositWalletBytecodeHash`. New storage: `mapMultisigDepositWallets`. New event: `DepositWalletLinked`. New interface: `IDepositWallet` (just `owner()`).
+- Mock contract: `contracts/test/MockDepositWalletFactory.sol`, mirroring the `MockPolySafeFactory.sol` pattern.
+- Tests:
+  - Unit (Hardhat or Forge): the canonical happy-path + failure modes (DW not pre-deployed, DW owner mismatch, DW codehash mismatch).
+  - Forge fork-test against Polygon: end-to-end `serviceManager.deploy → creator.create()` against the live `DepositWalletFactory` with a relayer-deployed DW. Pattern: `test/StakePolySafe.sol`'s `testExternalCreatePolySafeAndStake` is the closest analogue.
+- Off-chain (Pearl): new `predictDepositWalletAddress(agentInstance)` helper, relayer client integration (use `@polymarket/builder-relayer-client@0.0.9`), pre-tx orchestration of DW deploy + post-tx Phase 4 batch.
+- Estimated effort: ~3-4 days for the contract + tests; ~2-3 days for off-chain orchestration; ~1 day for governance proposal + whitelisting. ~1 week of focused engineering total.
+
+**Vuln-list items to record (acknowledged-not-blocking):**
+
+- CREATE2 front-running on the DW pre-deploy. Mitigated by the factory's collision-revert and the agent-instance EOA being a Pearl-internal value. No on-chain countermeasure required.
+- Relayer hard-dependency for new-account onboarding. Loss of the self-custody-from-minute-zero / permissionless-wallet-creation property. Architectural trade explicitly accepted by product.
+- DW-side recovery: relies on Privy's EOA custody. If Privy custody is breached, DW funds at risk. Out-of-scope for this contract; tracked at the product layer.
 
 ## Out of scope for this plan
 

--- a/contracts/multisigs/SafeAndDepositWalletCreator.sol
+++ b/contracts/multisigs/SafeAndDepositWalletCreator.sol
@@ -1,0 +1,188 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+// Safe Proxy Factory interface extracted from the mainnet: https://etherscan.io/address/0xa6b71e26c5e0845f74c812102ca7114b6a896ab2#code#F2#L61
+interface ISafeProxyFactory {
+    /// @dev Allows to create new proxy contact and execute a message call to the new proxy within one transaction.
+    /// @param _singleton Address of singleton contract.
+    /// @param initializer Payload for message call sent to new proxy contract.
+    /// @param saltNonce Nonce that will be used to generate the salt to calculate the address of the new proxy contract.
+    function createProxyWithNonce(
+        address _singleton,
+        bytes memory initializer,
+        uint256 saltNonce
+    ) external returns (address proxy);
+}
+
+// Polymarket Deposit Wallet interface: https://polygonscan.com/address/0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB#code
+interface IDepositWallet {
+    /// @dev Returns the EOA address that owns the deposit wallet.
+    /// @notice The owner is enforced as an externally owned account by the wallet's
+    ///         pure-ECDSA `_erc1271IsValidSignatureNowCalldata` override; smart contracts
+    ///         (including Safes) cannot be owners. The owner signs `WALLET` batches via the
+    ///         Polymarket relayer and CLOB orders via ERC-7739-wrapped POLY_1271 signatures.
+    function owner() external view returns (address);
+}
+
+/// @dev Provided zero address.
+error ZeroAddress();
+
+/// @dev Provided zero value.
+error ZeroValue();
+
+/// @dev Provided incorrect data length.
+/// @param expected Expected data length.
+/// @param provided Provided data length.
+error IncorrectDataLength(uint256 expected, uint256 provided);
+
+/// @dev Provided incorrect number of owners.
+/// @param expected Expected number of owners.
+/// @param provided Provided number of owners.
+error WrongNumOwners(uint256 expected, uint256 provided);
+
+/// @dev Deposit wallet has no code at the provided address.
+/// @param depositWallet Deposit wallet address.
+error DepositWalletNotDeployed(address depositWallet);
+
+/// @dev Provided incorrect deposit wallet owner.
+/// @param expected Expected deposit wallet owner.
+/// @param provided Provided deposit wallet owner.
+error WrongDepositWalletOwner(address expected, address provided);
+
+/// @dev Caught reentrancy violation.
+error ReentrancyGuard();
+
+/// @title SafeAndDepositWalletCreator - Smart contract for Safe multisig creation linked to a Polymarket deposit wallet
+/// @author Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>
+/// @author Andrey Lebedev - <andrey.lebedev@valory.xyz>
+/// @author Mariapia Moscatiello - <mariapia.moscatiello@valory.xyz>
+/// @notice The Safe multisig is the OLAS service multisig (governance, custody, ERC-8004 agent wallet, RecoveryModule).
+///         The Polymarket deposit wallet is a separate per-service trading account, deployed out-of-band by Polymarket's
+///         relayer with the agent-instance EOA as its owner. The two are independent peers bridged by the agent-instance
+///         EOA: the EOA is one of the Safe's owners and the deposit wallet's sole EOA owner. The deposit wallet cannot
+///         be owned by the Safe because its `_erc1271IsValidSignatureNowCalldata` is pure ECDSA, foreclosing
+///         smart-contract ownership.
+///         Pre-deploy ordering: Pearl client predicts the deposit wallet address off-chain (deterministic CREATE2 from
+///         the agent-instance EOA), HTTP-calls Polymarket's relayer to deploy the deposit wallet via
+///         `DepositWalletFactory.deploy` (operator-gated, no on-chain meta-tx variant available), then submits
+///         `ServiceManager.deploy(serviceId, this, data)` which calls this contract's `create()` to deploy the Safe with
+///         RecoveryModule enabled atomically and verify the pre-deployed deposit wallet.
+contract SafeAndDepositWalletCreator {
+    event MultisigCreated(address indexed multisig, address indexed agentInstance);
+    event DepositWalletLinked(address indexed multisig, address indexed depositWallet);
+
+    // Selector of the Safe setup function
+    bytes4 public constant SAFE_SETUP_SELECTOR = 0xb63e800d;
+    // Encoded selector of the Recovery module enableModule function
+    bytes4 public constant ENABLE_MODULE_SELECTOR = 0x24292962;
+    // Default data length: address + uint256 + address = 3 full slots = 96 (bytes)
+    uint256 public constant DEFAULT_DATA_LENGTH = 96;
+
+    // Safe contract address
+    address public immutable safe;
+    // Safe Factory contract address
+    address public immutable safeProxyFactory;
+    // Recovery module address
+    address public immutable recoveryModule;
+    // Polymarket Deposit Wallet Factory address
+    address public immutable depositWalletFactory;
+
+    // Multisig address => linked deposit wallet address
+    mapping(address => address) public mapMultisigDepositWallets;
+
+    // Reentrancy lock
+    uint256 internal _locked = 1;
+
+    /// @dev SafeAndDepositWalletCreator constructor.
+    /// @param _safe Safe contract address.
+    /// @param _safeProxyFactory Safe proxy factory contract address.
+    /// @param _recoveryModule Recovery module address.
+    /// @param _depositWalletFactory Polymarket Deposit Wallet Factory address.
+    constructor (
+        address _safe,
+        address _safeProxyFactory,
+        address _recoveryModule,
+        address _depositWalletFactory
+    ) {
+        // Check for zero addresses
+        if (_safe == address(0) || _safeProxyFactory == address(0) || _recoveryModule == address(0)
+            || _depositWalletFactory == address(0)) {
+            revert ZeroAddress();
+        }
+
+        safe = _safe;
+        safeProxyFactory = _safeProxyFactory;
+        recoveryModule = _recoveryModule;
+        depositWalletFactory = _depositWalletFactory;
+    }
+
+    /// @dev Creates a Safe multisig with Recovery Module enabled atomically and links it to a pre-deployed deposit wallet.
+    /// @notice Number of owners is required to be 1: the agent-instance EOA that bridges the Safe and the deposit wallet.
+    ///         The deposit wallet must already be deployed by Polymarket's relayer at the address provided in `data`.
+    /// @param owners Set of multisig owners. Must contain a single agent-instance EOA matching the deposit wallet owner.
+    /// @param threshold Number of required confirmations for a multisig transaction.
+    /// @param data Encoded `(address fallbackHandler, uint256 saltNonce, address depositWallet)` payload.
+    /// @return multisig Address of a created multisig.
+    function create(
+        address[] memory owners,
+        uint256 threshold,
+        bytes memory data
+    ) external returns (address multisig) {
+        // Reentrancy guard
+        if (_locked > 1) {
+            revert ReentrancyGuard();
+        }
+        _locked = 2;
+
+        // Single owner is required: the agent-instance EOA that owns the deposit wallet
+        if (owners.length != 1) {
+            revert WrongNumOwners(1, owners.length);
+        }
+
+        // Check for correct data length
+        uint256 dataLength = data.length;
+        if (dataLength != DEFAULT_DATA_LENGTH) {
+            revert IncorrectDataLength(DEFAULT_DATA_LENGTH, dataLength);
+        }
+
+        // Decode fallback handler, salt nonce and pre-deployed deposit wallet address
+        (address fallbackHandler, uint256 saltNonce, address depositWallet) =
+            abi.decode(data, (address, uint256, address));
+
+        // Verify the deposit wallet is deployed at the expected address
+        if (depositWallet.code.length == 0) {
+            revert DepositWalletNotDeployed(depositWallet);
+        }
+
+        // Verify the deposit wallet owner matches the agent-instance EOA: this is the bridge invariant linking the
+        // two peers and the load-bearing check enforced by Polymarket's pure-ECDSA `_erc1271IsValidSignatureNowCalldata`.
+        // Combined with code.length, the owner() lookup also implicitly authenticates the deposit wallet shape:
+        // a non-DW contract at the predicted address would either lack `owner()` (revert) or return a non-matching
+        // address (revert). A bytecode-hash check is not feasible because Polymarket's wallets use solady's
+        // `deployDeterministicERC1967WithImmutableArgs` variant, which bakes per-wallet immutable args
+        // (factory, walletId) into the proxy bytecode — so each wallet has a distinct runtime codehash.
+        address depositWalletOwner = IDepositWallet(depositWallet).owner();
+        if (depositWalletOwner != owners[0]) {
+            revert WrongDepositWalletOwner(owners[0], depositWalletOwner);
+        }
+
+        // Convert enableModule selector into bytes
+        bytes memory payload = bytes.concat(ENABLE_MODULE_SELECTOR);
+
+        // Encode the gnosis setup function parameters
+        bytes memory safeParams = abi.encodeWithSelector(SAFE_SETUP_SELECTOR, owners, threshold, recoveryModule,
+            payload, fallbackHandler, address(0), 0, payable(address(0)));
+
+        // Create a gnosis safe multisig via the proxy factory
+        multisig = ISafeProxyFactory(safeProxyFactory).createProxyWithNonce(safe, safeParams, saltNonce);
+
+        // Record the on-chain link such that third parties (8004 indexers, dashboards, traders) can discover a
+        // service's deposit wallet from its Safe without trusting off-chain configuration
+        mapMultisigDepositWallets[multisig] = depositWallet;
+
+        emit MultisigCreated(multisig, owners[0]);
+        emit DepositWalletLinked(multisig, depositWallet);
+
+        _locked = 1;
+    }
+}

--- a/contracts/test/MockDepositWalletFactory.sol
+++ b/contracts/test/MockDepositWalletFactory.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+/// @dev Mock of Polymarket's deposit wallet runtime: a minimal contract that exposes the EOA owner via `owner()`.
+/// @notice Polymarket's real deposit wallet (`0x58CA52ebe0DadfdF531Cde7062e76746de4Db1eB` on Polygon, deployed
+///         behind a solady `deployDeterministicERC1967` UUPS-style proxy) carries a much larger surface — session
+///         signers, timelocked withdrawals, ERC-7739 signature validation. None of that is exercised by the
+///         `SafeAndDepositWalletCreator`, which only verifies `code.length`, `codehash` and `owner`. This mock keeps
+///         the test surface narrow.
+contract MockDepositWallet {
+    address public owner;
+
+    constructor(address _owner) {
+        owner = _owner;
+    }
+}
+
+/// @dev Mock of Polymarket's `DepositWalletFactory.deploy` semantics for unit testing.
+/// @notice The real factory (`0x00000000000Fb5C9ADea0298D729A0CB3823Cc07` on Polygon) gates `deploy` with
+///         `onlyOperator`; the mock is permissionless so unit tests can drive it directly. Salt scheme matches
+///         the real factory's relayer convention: `salt = keccak256(abi.encode(factory, walletId))`, where the
+///         relayer-client uses `walletId = bytes32(uint256(uint160(owner)))` per the merged `derive.js` source
+///         (one owner = one wallet, ever).
+contract MockDepositWalletFactory {
+    event DepositWalletDeployed(address indexed wallet, address indexed owner);
+
+    /// @dev Provided arrays length mismatch.
+    error LengthMismatch();
+
+    /// @dev Deploys mock deposit wallets at deterministic CREATE2 addresses.
+    /// @param _owners Owner EOA for each wallet.
+    /// @param _ids Wallet id used in the salt (relayer convention is `bytes32(uint256(uint160(owner)))`).
+    function deploy(address[] calldata _owners, bytes32[] calldata _ids) external {
+        if (_owners.length != _ids.length) {
+            revert LengthMismatch();
+        }
+        for (uint256 i = 0; i < _owners.length; ++i) {
+            bytes32 salt = keccak256(abi.encode(address(this), _ids[i]));
+            address wallet = address(new MockDepositWallet{salt: salt}(_owners[i]));
+            emit DepositWalletDeployed(wallet, _owners[i]);
+        }
+    }
+
+    /// @dev Computes the deterministic CREATE2 address for a deposit wallet owned by `_owner`.
+    /// @notice Mirrors the real factory's salt convention with `walletId = bytes32(uint256(uint160(owner)))`.
+    /// @param _owner Owner EOA expected to own the deposit wallet.
+    /// @return Predicted deposit wallet address.
+    function computeWalletAddress(address _owner) external view returns (address) {
+        bytes32 walletId = bytes32(uint256(uint160(_owner)));
+        bytes32 salt = keccak256(abi.encode(address(this), walletId));
+        bytes memory initCode = abi.encodePacked(type(MockDepositWallet).creationCode, abi.encode(_owner));
+        bytes32 hash = keccak256(abi.encodePacked(bytes1(0xff), address(this), salt, keccak256(initCode)));
+        return address(uint160(uint256(hash)));
+    }
+
+}

--- a/test/SafeAndDepositWalletCreator.t.sol
+++ b/test/SafeAndDepositWalletCreator.t.sol
@@ -1,0 +1,292 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {Utils} from "./utils/Utils.sol";
+import {GnosisSafe} from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+import {GnosisSafeProxyFactory} from "@gnosis.pm/safe-contracts/contracts/proxies/GnosisSafeProxyFactory.sol";
+import {MultiSend} from "@gnosis.pm/safe-contracts/contracts/libraries/MultiSend.sol";
+import {DefaultCallbackHandler} from "@gnosis.pm/safe-contracts/contracts/handler/DefaultCallbackHandler.sol";
+import {RecoveryModule} from "../contracts/multisigs/RecoveryModule.sol";
+import {
+    SafeAndDepositWalletCreator,
+    ZeroAddress,
+    IncorrectDataLength,
+    WrongNumOwners,
+    DepositWalletNotDeployed,
+    WrongDepositWalletOwner
+} from "../contracts/multisigs/SafeAndDepositWalletCreator.sol";
+import {MockDepositWalletFactory, MockDepositWallet} from "../contracts/test/MockDepositWalletFactory.sol";
+
+contract BaseSetup is Test {
+    Utils internal utils;
+    GnosisSafe internal gnosisSafe;
+    GnosisSafeProxyFactory internal gnosisSafeProxyFactory;
+    DefaultCallbackHandler internal fallbackHandler;
+    MultiSend internal multiSend;
+    RecoveryModule internal recoveryModule;
+    MockDepositWalletFactory internal depositWalletFactory;
+    SafeAndDepositWalletCreator internal creator;
+
+    address payable[] internal users;
+    address internal deployer;
+
+    function setUp() public virtual {
+        utils = new Utils();
+        users = utils.createUsers(10);
+        deployer = users[0];
+        vm.label(deployer, "Deployer");
+
+        // Deploy Safe infrastructure
+        gnosisSafe = new GnosisSafe();
+        gnosisSafeProxyFactory = new GnosisSafeProxyFactory();
+        fallbackHandler = new DefaultCallbackHandler();
+        multiSend = new MultiSend();
+
+        // Deploy recovery module (serviceRegistry not exercised in the create() path, any non-zero address suffices)
+        recoveryModule = new RecoveryModule(address(multiSend), address(gnosisSafe));
+
+        // Deploy deposit wallet mock factory
+        depositWalletFactory = new MockDepositWalletFactory();
+
+        // Deploy creator
+        creator = new SafeAndDepositWalletCreator(
+            address(gnosisSafe),
+            address(gnosisSafeProxyFactory),
+            address(recoveryModule),
+            address(depositWalletFactory)
+        );
+    }
+
+    /// @dev Pre-deploys a mock deposit wallet for `_owner` via the mock factory and returns the address.
+    function _preDeployDepositWallet(address _owner) internal returns (address) {
+        address[] memory owners = new address[](1);
+        owners[0] = _owner;
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = bytes32(uint256(uint160(_owner)));
+
+        address predicted = depositWalletFactory.computeWalletAddress(_owner);
+        depositWalletFactory.deploy(owners, ids);
+
+        return predicted;
+    }
+}
+
+contract SafeAndDepositWalletCreatorConstructor is BaseSetup {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// @dev Constructor reverts on any zero address.
+    function testConstructor_RevertsOnZeroAddress() public {
+        vm.expectRevert(ZeroAddress.selector);
+        new SafeAndDepositWalletCreator(
+            address(0), address(gnosisSafeProxyFactory), address(recoveryModule), address(depositWalletFactory)
+        );
+
+        vm.expectRevert(ZeroAddress.selector);
+        new SafeAndDepositWalletCreator(
+            address(gnosisSafe), address(0), address(recoveryModule), address(depositWalletFactory)
+        );
+
+        vm.expectRevert(ZeroAddress.selector);
+        new SafeAndDepositWalletCreator(
+            address(gnosisSafe), address(gnosisSafeProxyFactory), address(0), address(depositWalletFactory)
+        );
+
+        vm.expectRevert(ZeroAddress.selector);
+        new SafeAndDepositWalletCreator(
+            address(gnosisSafe), address(gnosisSafeProxyFactory), address(recoveryModule), address(0)
+        );
+    }
+
+    /// @dev Constructor stores all immutables and constants.
+    function testConstructor_StoresImmutables() public view {
+        assertEq(creator.safe(), address(gnosisSafe));
+        assertEq(creator.safeProxyFactory(), address(gnosisSafeProxyFactory));
+        assertEq(creator.recoveryModule(), address(recoveryModule));
+        assertEq(creator.depositWalletFactory(), address(depositWalletFactory));
+        assertEq(creator.SAFE_SETUP_SELECTOR(), bytes4(0xb63e800d));
+        assertEq(creator.ENABLE_MODULE_SELECTOR(), bytes4(0x24292962));
+        assertEq(creator.DEFAULT_DATA_LENGTH(), 96);
+    }
+}
+
+contract SafeAndDepositWalletCreatorCreate is BaseSetup {
+    function setUp() public override {
+        super.setUp();
+    }
+
+    /// @dev Happy path: pre-deploy a DW, then call create() with a single owner matching the DW owner.
+    function testCreate_HappyPath() public {
+        address agentInstance = users[1];
+        address depositWallet = _preDeployDepositWallet(agentInstance);
+
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(1), depositWallet);
+
+        address multisig = creator.create(owners, 1, data);
+
+        // Multisig is a Safe with one owner equal to agentInstance and threshold one
+        GnosisSafe safe = GnosisSafe(payable(multisig));
+        assertEq(safe.getThreshold(), 1);
+        address[] memory safeOwners = safe.getOwners();
+        assertEq(safeOwners.length, 1);
+        assertEq(safeOwners[0], agentInstance);
+
+        // Recovery module is enabled
+        assertTrue(safe.isModuleEnabled(address(recoveryModule)));
+
+        // Deposit wallet linkage is recorded
+        assertEq(creator.mapMultisigDepositWallets(multisig), depositWallet);
+        assertEq(MockDepositWallet(depositWallet).owner(), agentInstance);
+    }
+
+    /// @dev Both events are emitted with the expected indexed topics.
+    function testCreate_EmitsEvents() public {
+        address agentInstance = users[2];
+        address depositWallet = _preDeployDepositWallet(agentInstance);
+
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(2), depositWallet);
+
+        vm.recordLogs();
+        address multisig = creator.create(owners, 1, data);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        bytes32 createdSig = keccak256("MultisigCreated(address,address)");
+        bytes32 linkedSig = keccak256("DepositWalletLinked(address,address)");
+        bool sawCreated;
+        bool sawLinked;
+        for (uint256 i = 0; i < entries.length; ++i) {
+            if (entries[i].emitter != address(creator)) continue;
+            if (entries[i].topics[0] == createdSig) {
+                assertEq(address(uint160(uint256(entries[i].topics[1]))), multisig);
+                assertEq(address(uint160(uint256(entries[i].topics[2]))), agentInstance);
+                sawCreated = true;
+            } else if (entries[i].topics[0] == linkedSig) {
+                assertEq(address(uint160(uint256(entries[i].topics[1]))), multisig);
+                assertEq(address(uint160(uint256(entries[i].topics[2]))), depositWallet);
+                sawLinked = true;
+            }
+        }
+        assertTrue(sawCreated);
+        assertTrue(sawLinked);
+    }
+
+    /// @dev Reverts when the deposit wallet has not been pre-deployed at the predicted address.
+    function testCreate_RevertsWhenDepositWalletNotDeployed() public {
+        address agentInstance = users[3];
+        address predicted = depositWalletFactory.computeWalletAddress(agentInstance);
+
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(0), predicted);
+
+        vm.expectRevert(abi.encodeWithSelector(DepositWalletNotDeployed.selector, predicted));
+        creator.create(owners, 1, data);
+    }
+
+    /// @dev Reverts when the contract at the deposit wallet slot does not expose the `IDepositWallet.owner()` shape.
+    /// @notice Combined with `code.length > 0`, the `owner()` staticcall provides the practical defense against
+    ///         arbitrary contracts at the predicted address: a non-DW contract at the address either lacks
+    ///         `owner()` (the staticcall reverts and bubbles up) or returns a non-matching address (caught by
+    ///         the `WrongDepositWalletOwner` check). A bytecode hash check is not feasible because Polymarket's
+    ///         wallets bake per-wallet immutable args into bytecode.
+    function testCreate_RevertsOnNonDepositWalletAtAddress() public {
+        address agentInstance = users[4];
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+
+        // The Safe singleton has code but no `owner()` getter — staticcall will revert
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(0), address(gnosisSafe));
+
+        vm.expectRevert();
+        creator.create(owners, 1, data);
+    }
+
+    /// @dev Reverts when the deposit wallet's owner does not match the first owner.
+    function testCreate_RevertsWhenDepositWalletOwnerMismatch() public {
+        address agentInstance = users[5];
+        address other = users[6];
+        address depositWallet = _preDeployDepositWallet(other);
+
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(0), depositWallet);
+
+        vm.expectRevert(abi.encodeWithSelector(WrongDepositWalletOwner.selector, agentInstance, other));
+        creator.create(owners, 1, data);
+    }
+
+    /// @dev Reverts when zero owners are provided.
+    function testCreate_RevertsOnZeroOwners() public {
+        address[] memory owners = new address[](0);
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(0), address(0));
+
+        vm.expectRevert(abi.encodeWithSelector(WrongNumOwners.selector, 1, 0));
+        creator.create(owners, 1, data);
+    }
+
+    /// @dev Reverts when more than one owner is provided.
+    function testCreate_RevertsOnMultipleOwners() public {
+        address[] memory owners = new address[](2);
+        owners[0] = users[1];
+        owners[1] = users[2];
+        bytes memory data = abi.encode(address(fallbackHandler), uint256(0), address(0));
+
+        vm.expectRevert(abi.encodeWithSelector(WrongNumOwners.selector, 1, 2));
+        creator.create(owners, 1, data);
+    }
+
+    /// @dev Reverts when data length does not match the expected encoding.
+    function testCreate_RevertsOnIncorrectDataLength() public {
+        address agentInstance = users[7];
+        _preDeployDepositWallet(agentInstance);
+
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+
+        // Too short (matches SafeMultisigWithRecoveryModule's 64-byte payload)
+        bytes memory shortData = abi.encode(address(fallbackHandler), uint256(0));
+        vm.expectRevert(abi.encodeWithSelector(IncorrectDataLength.selector, 96, 64));
+        creator.create(owners, 1, shortData);
+
+        // Empty data
+        vm.expectRevert(abi.encodeWithSelector(IncorrectDataLength.selector, 96, 0));
+        creator.create(owners, 1, "");
+
+        // Too long
+        bytes memory longData = abi.encode(address(fallbackHandler), uint256(0), address(0), uint256(0));
+        vm.expectRevert(abi.encodeWithSelector(IncorrectDataLength.selector, 96, 128));
+        creator.create(owners, 1, longData);
+    }
+
+    /// @dev Mapping is populated only on successful create; entries for distinct services are independent.
+    function testCreate_MappingIsPopulatedAndPreservedAcrossCalls() public {
+        address agentA = users[1];
+        address agentB = users[2];
+
+        address dwA = _preDeployDepositWallet(agentA);
+        address dwB = _preDeployDepositWallet(agentB);
+
+        address[] memory ownersA = new address[](1);
+        ownersA[0] = agentA;
+        address multisigA = creator.create(ownersA, 1, abi.encode(address(fallbackHandler), uint256(11), dwA));
+
+        address[] memory ownersB = new address[](1);
+        ownersB[0] = agentB;
+        address multisigB = creator.create(ownersB, 1, abi.encode(address(fallbackHandler), uint256(22), dwB));
+
+        assertEq(creator.mapMultisigDepositWallets(multisigA), dwA);
+        assertEq(creator.mapMultisigDepositWallets(multisigB), dwB);
+        assertTrue(multisigA != multisigB);
+    }
+}

--- a/test/SafeAndDepositWalletCreatorFork.sol
+++ b/test/SafeAndDepositWalletCreatorFork.sol
@@ -1,0 +1,486 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.30;
+
+import {Test} from "forge-std/Test.sol";
+import {Vm} from "forge-std/Vm.sol";
+import {Utils} from "./utils/Utils.sol";
+import {GnosisSafe, Enum} from "@gnosis.pm/safe-contracts/contracts/GnosisSafe.sol";
+import {SignMessageLib} from "@gnosis.pm/safe-contracts/contracts/examples/libraries/SignMessage.sol";
+import {SafeAndDepositWalletCreator, IDepositWallet} from "../contracts/multisigs/SafeAndDepositWalletCreator.sol";
+
+// Polymarket DepositWalletFactory ABI subset used by this fork test
+interface IDepositWalletFactory {
+    function deploy(address[] calldata _owners, bytes32[] calldata _ids) external;
+    function rolesOf(address) external view returns (uint256);
+}
+
+/// @dev Fork test only. Run with `forge test -f $POLYGON_RPC_URL --match-contract SafeAndDepositWalletCreatorFork -vvv`.
+contract SafeAndDepositWalletCreatorFork is Test {
+    Utils internal utils;
+
+    // Polygon mainnet pre-deployed addresses (sourced from scripts/deployment/l2/globals_polygon_mainnet.json
+    // and the merged @polymarket/builder-relayer-client@0.0.9 src/config/index.ts)
+    address internal constant SAFE_SINGLETON = 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552;
+    address internal constant SAFE_PROXY_FACTORY = 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2;
+    address internal constant RECOVERY_MODULE = 0x02C26437B292D86c5F4F21bbCcE0771948274f84;
+    address internal constant DEPOSIT_WALLET_FACTORY = 0x00000000000Fb5C9ADea0298D729A0CB3823Cc07;
+    address internal constant FALLBACK_HANDLER = 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4;
+
+    // Known caller of the very first DepositWalletFactory.deploy() on Polygon (block 86272144,
+    // 2026-05-01T19:38:52Z). Almost certainly Polymarket's operator EOA. If this address ever loses the
+    // operator role on-chain, capture a fresh operator from a recent factory event and update.
+    address internal constant POLYMARKET_OPERATOR = 0x829BDEf266CEA938A81D911BaA68b5D138b3ba02;
+
+    SafeAndDepositWalletCreator internal creator;
+
+    function setUp() public {
+        utils = new Utils();
+
+        creator = new SafeAndDepositWalletCreator(
+            SAFE_SINGLETON,
+            SAFE_PROXY_FACTORY,
+            RECOVERY_MODULE,
+            DEPOSIT_WALLET_FACTORY
+        );
+    }
+
+    /// @dev Impersonates the Polymarket operator EOA and calls `DepositWalletFactory.deploy` for `_agent`,
+    ///      mirroring what the relayer does in production. Reads the deployed wallet address from the deploy
+    ///      logs rather than predicting it on-chain — this avoids depending on solady's ERC1967 init-code hash,
+    ///      which would otherwise need to be captured separately from the runtime codehash.
+    function _operatorDeployDepositWallet(address _agent) internal returns (address depositWallet) {
+        address[] memory owners = new address[](1);
+        owners[0] = _agent;
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = bytes32(uint256(uint160(_agent)));
+
+        // Confirm the impersonated EOA still has the operator role
+        require(IDepositWalletFactory(DEPOSIT_WALLET_FACTORY).rolesOf(POLYMARKET_OPERATOR) != 0,
+            "POLYMARKET_OPERATOR no longer has operator role; capture a fresh operator and update");
+
+        vm.recordLogs();
+
+        vm.prank(POLYMARKET_OPERATOR);
+        IDepositWalletFactory(DEPOSIT_WALLET_FACTORY).deploy(owners, ids);
+
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        // Locate the new deposit wallet by scanning logs for any `address.code.length > 0` event emitter that
+        // didn't have code before this call. Most robust against unknown event signatures: the first newly
+        // code-bearing emitter under the factory's deploy is the wallet.
+        for (uint256 i = 0; i < entries.length; ++i) {
+            address emitter = entries[i].emitter;
+            if (emitter == DEPOSIT_WALLET_FACTORY) continue;
+            if (emitter.code.length == 0) continue;
+            // Must own the expected agent
+            try IDepositWallet(emitter).owner() returns (address ownerEoa) {
+                if (ownerEoa == _agent) {
+                    depositWallet = emitter;
+                    break;
+                }
+            } catch {}
+        }
+        require(depositWallet != address(0), "deposit wallet address not found in deploy logs");
+    }
+
+    // -----------------------------------------------------------------------
+    // Tests
+    // -----------------------------------------------------------------------
+
+    /// @dev Happy path on a forked chain: relayer-style operator pre-deploys a DW, then the creator deploys a Safe
+    ///      with RecoveryModule enabled and links the DW.
+    function testFork_Create_HappyPath() public {
+        (address agentInstance, ) = makeAddrAndKey("agentInstance-fork-happy");
+
+        // Phase 2 (off-chain HTTP in production): operator pre-deploys the deposit wallet
+        address depositWallet = _operatorDeployDepositWallet(agentInstance);
+
+        // Phase 3 (single on-chain user tx): creator deploys the Safe + RecoveryModule and verifies the DW
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+        bytes memory data = abi.encode(FALLBACK_HANDLER, uint256(uint160(agentInstance)), depositWallet);
+
+        address multisig = creator.create(owners, 1, data);
+
+        // Multisig is a freshly deployed Safe with the agent as sole owner, threshold one, recovery module enabled
+        GnosisSafe safe = GnosisSafe(payable(multisig));
+        assertEq(safe.getThreshold(), 1);
+        address[] memory safeOwners = safe.getOwners();
+        assertEq(safeOwners.length, 1);
+        assertEq(safeOwners[0], agentInstance);
+        assertTrue(safe.isModuleEnabled(RECOVERY_MODULE));
+
+        // Deposit wallet linkage is recorded on-chain
+        assertEq(creator.mapMultisigDepositWallets(multisig), depositWallet);
+
+        // The deposit wallet is reachable and owned by the agent EOA
+        bytes memory ownerCallData = abi.encodeWithSignature("owner()");
+        (bool ok, bytes memory ret) = depositWallet.staticcall(ownerCallData);
+        assertTrue(ok);
+        assertEq(abi.decode(ret, (address)), agentInstance);
+    }
+
+    /// @dev Two services with distinct agent EOAs each get a distinct (Safe, deposit wallet) pair.
+    function testFork_Create_TwoServicesAreIndependent() public {
+        (address agentA, ) = makeAddrAndKey("agentInstance-fork-A");
+        (address agentB, ) = makeAddrAndKey("agentInstance-fork-B");
+
+        address dwA = _operatorDeployDepositWallet(agentA);
+        address dwB = _operatorDeployDepositWallet(agentB);
+        assertTrue(dwA != dwB);
+
+        address[] memory ownersA = new address[](1);
+        ownersA[0] = agentA;
+        address multisigA = creator.create(ownersA, 1, abi.encode(FALLBACK_HANDLER, uint256(101), dwA));
+
+        address[] memory ownersB = new address[](1);
+        ownersB[0] = agentB;
+        address multisigB = creator.create(ownersB, 1, abi.encode(FALLBACK_HANDLER, uint256(102), dwB));
+
+        assertTrue(multisigA != multisigB);
+        assertEq(creator.mapMultisigDepositWallets(multisigA), dwA);
+        assertEq(creator.mapMultisigDepositWallets(multisigB), dwB);
+    }
+
+    /// @dev Reverts when the deposit wallet is not pre-deployed: simulates the relayer being unreachable at the
+    ///      moment the user submits the on-chain tx.
+    function testFork_Create_RevertsWhenRelayerSkipped() public {
+        (address agentInstance, ) = makeAddrAndKey("agentInstance-fork-norelayer");
+        // Use any address with no code as the "deposit wallet" — the predicted address would not exist either
+        address noCodeAddr = makeAddr("not-a-deposit-wallet");
+        assertEq(noCodeAddr.code.length, 0);
+
+        address[] memory owners = new address[](1);
+        owners[0] = agentInstance;
+        bytes memory data = abi.encode(FALLBACK_HANDLER, uint256(0), noCodeAddr);
+
+        vm.expectRevert();
+        creator.create(owners, 1, data);
+    }
+}
+
+// Subset of the Polygon-deployed ServiceManager / ServiceRegistry / ERC20 ABI used by the e2e test
+interface IServiceManager {
+    struct AgentParams { uint32 slots; uint96 bond; }
+    function ETH_TOKEN_ADDRESS() external view returns (address);
+    function create(
+        address serviceOwner,
+        address token,
+        bytes32 configHash,
+        uint32[] memory agentIds,
+        AgentParams[] memory agentParams,
+        uint32 threshold
+    ) external returns (uint256 serviceId);
+    function activateRegistration(uint256 serviceId) external payable;
+    function registerAgents(uint256 serviceId, address[] memory agentInstances, uint32[] memory agentIds)
+        external payable;
+    function deploy(uint256 serviceId, address multisigImplementation, bytes memory data)
+        external returns (address multisig);
+}
+
+interface IServiceRegistry {
+    function mapServices(uint256 serviceId) external view returns (
+        uint96 securityDeposit, address multisig, bytes32 configHash, uint32 threshold,
+        uint32 maxNumAgentInstances, uint32 numAgentInstances, uint8 state
+    );
+    function changeMultisigPermission(address multisig, bool permission) external;
+}
+
+interface IERC20Like {
+    function approve(address spender, uint256 amount) external returns (bool);
+    function balanceOf(address account) external view returns (uint256);
+}
+
+interface IIdentityRegistryBridger {
+    function mapMultisigAgentIds(address multisig) external view returns (uint256);
+    function setAgentWallet(uint256 deadline, bytes memory signature) external;
+}
+
+interface IIdentityRegistry {
+    function getAgentWallet(uint256 agentId) external view returns (address);
+    function ownerOf(uint256 agentId) external view returns (address);
+    function eip712Domain() external view returns (
+        bytes1 fields, string memory name, string memory version, uint256 chainId,
+        address verifyingContract, bytes32 salt, uint256[] memory extensions
+    );
+}
+
+/// @dev End-to-end fork test: walks Phase 1 (OLAS service registration, multiple user txs), Phase 2 (off-chain
+///      HTTP simulated via the impersonated Polymarket operator), and Phase 3 (the single on-chain user tx that
+///      runs `serviceManager.deploy` → `creator.create`). Demonstrates the design lock-in: any number of off-chain
+///      calls + exactly one on-chain user tx for the load-bearing deploy step. Run with
+///      `forge test -f $POLYGON_RPC_URL --match-contract SafeAndDepositWalletCreatorE2E -vvv`.
+contract SafeAndDepositWalletCreatorE2E is Test {
+    Utils internal utils;
+
+    // Polygon mainnet pre-deployed addresses (from scripts/deployment/l2/globals_polygon_mainnet.json
+    // and the Polymarket deposit-wallet stack)
+    address internal constant SAFE_SINGLETON = 0xd9Db270c1B5E3Bd161E8c8503c55cEABeE709552;
+    address internal constant SAFE_PROXY_FACTORY = 0xa6B71E26C5e0845f74c812102Ca7114b6a896AB2;
+    address internal constant RECOVERY_MODULE = 0x02C26437B292D86c5F4F21bbCcE0771948274f84;
+    address internal constant DEPOSIT_WALLET_FACTORY = 0x00000000000Fb5C9ADea0298D729A0CB3823Cc07;
+    address internal constant FALLBACK_HANDLER = 0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4;
+    address internal constant POLYMARKET_OPERATOR = 0x829BDEf266CEA938A81D911BaA68b5D138b3ba02;
+
+    address internal constant SERVICE_REGISTRY = 0xE3607b00E75f6405248323A9417ff6b39B244b50;
+    address internal constant SERVICE_MANAGER_PROXY = 0xE3e5Df46060370af5Fd37B2aA11e7dac3cCB4bd0;
+    address internal constant SERVICE_REGISTRY_TOKEN_UTILITY = 0xa45E64d13A30a51b91ae0eb182e88a40e9b18eD8;
+    address internal constant OLAS = 0xFEF5d947472e72Efbb2E388c730B7428406F2F95;
+    // Bridge mediator on Polygon — owns ServiceRegistryL2 on this chain (governance flows from mainnet timelock
+    // through the AMB bridge to this address; in production it would receive a cross-chain message)
+    address internal constant SERVICE_REGISTRY_OWNER = 0x9338b5153AE39BB89f50468E608eD9d764B755fD;
+    address internal constant IDENTITY_REGISTRY_BRIDGER_PROXY = 0x6F121552765424f0B2331B541C0938480cA314Db;
+    address internal constant IDENTITY_REGISTRY = 0x8004A169FB4a3325136EB29fA0ceB6D2e539a432;
+
+    bytes32 internal constant CONFIG_HASH = 0x4d82a931d803e2b46b0dcd53f558f8de8305fd44b36288b42287ef1450a6611f;
+
+    SafeAndDepositWalletCreator internal creator;
+
+    address payable[] internal users;
+    address internal deployer;
+
+    function setUp() public {
+        utils = new Utils();
+        users = utils.createUsers(5);
+        deployer = users[0];
+        vm.deal(deployer, 5 ether);
+
+        // Deploy creator
+        creator = new SafeAndDepositWalletCreator(
+            SAFE_SINGLETON, SAFE_PROXY_FACTORY, RECOVERY_MODULE, DEPOSIT_WALLET_FACTORY
+        );
+
+        // Whitelist creator on the on-chain ServiceRegistryL2. In production this requires a governance proposal
+        // on mainnet that bridges through the AMB to the Polygon mediator; here we vm.prank the mediator directly
+        vm.prank(SERVICE_REGISTRY_OWNER);
+        IServiceRegistry(SERVICE_REGISTRY).changeMultisigPermission(address(creator), true);
+    }
+
+    /// @dev Impersonates the Polymarket operator EOA and calls `DepositWalletFactory.deploy` for `_agent`. Reads
+    ///      the deployed wallet address back from the deploy logs.
+    function _operatorDeployDepositWallet(address _agent) internal returns (address depositWallet) {
+        address[] memory owners = new address[](1);
+        owners[0] = _agent;
+        bytes32[] memory ids = new bytes32[](1);
+        ids[0] = bytes32(uint256(uint160(_agent)));
+
+        require(IDepositWalletFactory(DEPOSIT_WALLET_FACTORY).rolesOf(POLYMARKET_OPERATOR) != 0,
+            "POLYMARKET_OPERATOR no longer has operator role; capture a fresh operator and update");
+
+        vm.recordLogs();
+        vm.prank(POLYMARKET_OPERATOR);
+        IDepositWalletFactory(DEPOSIT_WALLET_FACTORY).deploy(owners, ids);
+        Vm.Log[] memory entries = vm.getRecordedLogs();
+
+        for (uint256 i = 0; i < entries.length; ++i) {
+            address emitter = entries[i].emitter;
+            if (emitter == DEPOSIT_WALLET_FACTORY) continue;
+            if (emitter.code.length == 0) continue;
+            try IDepositWallet(emitter).owner() returns (address ownerEoa) {
+                if (ownerEoa == _agent) {
+                    depositWallet = emitter;
+                    break;
+                }
+            } catch {}
+        }
+        require(depositWallet != address(0), "deposit wallet address not found in deploy logs");
+    }
+
+    /// @dev Full end-to-end workflow against real Polygon mainnet contracts: off-chain DW pre-deploy + on-chain
+    ///      service registration + the single load-bearing on-chain deploy tx that runs creator.create().
+    function testForkE2E_FullWorkflow() public {
+        // ---- T = 0 (off-chain compute, no calls) ---------------------------------------------------------------
+        (address agentInstance, ) = makeAddrAndKey("agentInstance-e2e");
+
+        // ---- T = 0+ (off-chain HTTP call: relayer pre-deploys the deposit wallet — Phase 2) ----------------------
+        address depositWallet = _operatorDeployDepositWallet(agentInstance);
+        assertEq(IDepositWallet(depositWallet).owner(), agentInstance);
+
+        // ---- Phase 1: OLAS service registration (multiple user txs, none affect the deposit wallet) ---------------
+        deal(OLAS, deployer, 50000 ether);
+        IServiceManager.AgentParams[] memory agentParams = new IServiceManager.AgentParams[](1);
+        agentParams[0].slots = 1;
+        agentParams[0].bond = 50 ether;
+        uint32[] memory agentIds = new uint32[](1);
+        agentIds[0] = 86;
+
+        vm.startPrank(deployer);
+        IERC20Like(OLAS).approve(SERVICE_REGISTRY_TOKEN_UTILITY, 1000 ether);
+        uint256 serviceId = IServiceManager(SERVICE_MANAGER_PROXY).create(
+            deployer, OLAS, CONFIG_HASH, agentIds, agentParams, 1
+        );
+        IServiceManager(SERVICE_MANAGER_PROXY).activateRegistration{value: 1}(serviceId);
+        address[] memory agentInstances = new address[](1);
+        agentInstances[0] = agentInstance;
+        IServiceManager(SERVICE_MANAGER_PROXY).registerAgents{value: 1}(serviceId, agentInstances, agentIds);
+        vm.stopPrank();
+
+        // ---- T = max(Phase1, Phase2): Phase 3 — THE SINGLE LOAD-BEARING ON-CHAIN USER TRANSACTION ------------------
+        // Pearl submits this tx; ServiceManager.deploy → creator.create runs atomically.
+        bytes memory data = abi.encode(FALLBACK_HANDLER, uint256(uint160(agentInstance)), depositWallet);
+        vm.prank(deployer);
+        IServiceManager(SERVICE_MANAGER_PROXY).deploy(serviceId, address(creator), data);
+
+        // ---- End-state verification ----------------------------------------------------------------------------
+        (, address multisig, , , , , uint8 state) =
+            IServiceRegistry(SERVICE_REGISTRY).mapServices(serviceId);
+
+        // Service is in Deployed state (4)
+        assertEq(state, 4);
+
+        // Multisig is a Safe with the agent EOA as sole owner and the recovery module enabled
+        GnosisSafe safe = GnosisSafe(payable(multisig));
+        address[] memory safeOwners = safe.getOwners();
+        assertEq(safeOwners.length, 1);
+        assertEq(safeOwners[0], agentInstance);
+        assertEq(safe.getThreshold(), 1);
+        assertTrue(safe.isModuleEnabled(RECOVERY_MODULE));
+
+        // Deposit wallet linkage is recorded on the creator and discoverable on-chain by third parties
+        assertEq(creator.mapMultisigDepositWallets(multisig), depositWallet);
+
+        // The deposit wallet is owned by the agent EOA — Pearl can now sign Phase 4 batches via Privy and submit
+        // them to the Polymarket relayer's `proxy()` endpoint to authorize session signers and approve trading
+        // collateral on the deposit wallet. Phase 4 batch construction is off-chain orchestration that does not
+        // affect the on-chain Safe state, so we don't exercise it here — but the link is in place.
+        assertEq(IDepositWallet(depositWallet).owner(), agentInstance);
+    }
+
+    /// @dev Demonstrates the full ERC-8004 `setAgentWallet` flow through the new Safe — the same pattern used by
+    ///      `ServiceManagerNative.js`'s middleware-workflow test for the existing PolySafe path. The Safe is set up
+    ///      with the Polygon-canonical CompatibilityFallbackHandler, so its ERC-1271 `isValidSignature` follows the
+    ///      `signedMessages` lookup path. The agent EOA executes a Safe-tx that delegatecalls `SignMessageLib` to
+    ///      pre-store the IdentityRegistry's `AgentWalletSet` typed-data digest, then a second Safe-tx calls
+    ///      `bridger.setAgentWallet(deadline, "")` — IdentityRegistry's ERC-1271 check passes against the empty
+    ///      signature because the digest is in `signedMessages`. **No `SignMessageLib` logic is "ported" by the
+    ///      creator contract** — this is the standard Safe v1.3.0 + CompatibilityFallbackHandler flow, equivalent
+    ///      to what the existing PolySafe creator inherits via Polymarket's PolySafeProxyFactory.
+    function testForkE2E_SetAgentWalletViaSignMessageLib() public {
+        (address agentInstance, uint256 agentInstancePk) = makeAddrAndKey("agentInstance-setagent");
+        address multisig = _runDeployWorkflow(agentInstance);
+        _signAndSetAgentWallet(GnosisSafe(payable(multisig)), agentInstance, agentInstancePk);
+
+        // IdentityRegistry now records the multisig as the agent wallet
+        uint256 agentId = IIdentityRegistryBridger(IDENTITY_REGISTRY_BRIDGER_PROXY).mapMultisigAgentIds(multisig);
+        assertEq(IIdentityRegistry(IDENTITY_REGISTRY).getAgentWallet(agentId), multisig);
+    }
+
+    /// @dev Walks Phase 1 + 2 + 3 of the workflow and returns the deployed multisig.
+    function _runDeployWorkflow(address _agentInstance) internal returns (address multisig) {
+        address depositWallet = _operatorDeployDepositWallet(_agentInstance);
+
+        deal(OLAS, deployer, 50000 ether);
+        IServiceManager.AgentParams[] memory agentParams = new IServiceManager.AgentParams[](1);
+        agentParams[0].slots = 1;
+        agentParams[0].bond = 50 ether;
+        uint32[] memory agentIds = new uint32[](1);
+        agentIds[0] = 86;
+
+        vm.startPrank(deployer);
+        IERC20Like(OLAS).approve(SERVICE_REGISTRY_TOKEN_UTILITY, 1000 ether);
+        uint256 serviceId = IServiceManager(SERVICE_MANAGER_PROXY).create(
+            deployer, OLAS, CONFIG_HASH, agentIds, agentParams, 1
+        );
+        IServiceManager(SERVICE_MANAGER_PROXY).activateRegistration{value: 1}(serviceId);
+        address[] memory agentInstances = new address[](1);
+        agentInstances[0] = _agentInstance;
+        IServiceManager(SERVICE_MANAGER_PROXY).registerAgents{value: 1}(serviceId, agentInstances, agentIds);
+        vm.stopPrank();
+
+        // Fallback handler must be the CompatibilityFallbackHandler so the Safe's ERC-1271
+        // `isValidSignature(bytes32,bytes)` routes through the `signedMessages` path
+        bytes memory data = abi.encode(FALLBACK_HANDLER, uint256(uint160(_agentInstance)), depositWallet);
+        vm.prank(deployer);
+        IServiceManager(SERVICE_MANAGER_PROXY).deploy(serviceId, address(creator), data);
+
+        (, multisig, , , , , ) = IServiceRegistry(SERVICE_REGISTRY).mapServices(serviceId);
+    }
+
+    /// @dev Pre-signs the IdentityRegistry's `AgentWalletSet` digest via `SignMessageLib`, then submits the
+    ///      `bridger.setAgentWallet(deadline, "")` call from the multisig.
+    function _signAndSetAgentWallet(GnosisSafe _safe, address _agentInstance, uint256 _signerPk) internal {
+        // Pre-checks: agent is registered in the bridger but agentWallet on the IdentityRegistry is unset
+        uint256 agentId =
+            IIdentityRegistryBridger(IDENTITY_REGISTRY_BRIDGER_PROXY).mapMultisigAgentIds(address(_safe));
+        require(agentId > 0, "agent not registered");
+        address agentNftOwner = IIdentityRegistry(IDENTITY_REGISTRY).ownerOf(agentId);
+        require(agentNftOwner == IDENTITY_REGISTRY_BRIDGER_PROXY, "unexpected agent owner");
+        require(IIdentityRegistry(IDENTITY_REGISTRY).getAgentWallet(agentId) == address(0), "wallet already set");
+
+        // Build the EIP-712 digest the IdentityRegistry's `setAgentWallet` will validate
+        uint256 deadline = block.timestamp + 100;
+        bytes32 digest = _agentWalletSetDigest(agentId, address(_safe), agentNftOwner, deadline);
+
+        // Step 1: pre-sign the digest via SignMessageLib delegatecall
+        SignMessageLib signMessageLib = new SignMessageLib();
+        bytes memory signMsgCall =
+            abi.encodeCall(SignMessageLib.signMessage, (abi.encodePacked(digest)));
+        _execSafeTx(_safe, _signerPk, address(signMessageLib), 0, signMsgCall, Enum.Operation.DelegateCall);
+        // CompatibilityFallbackHandler will look up `signedMessages[_safeMessageHash(safe, digest)]`
+        require(_safe.signedMessages(_safeMessageHash(address(_safe), digest)) != 0, "message not signed");
+
+        // Step 2: call `bridger.setAgentWallet(deadline, "")` from the multisig — IdentityRegistry tries ECDSA
+        // first (fails since recovered != newWallet), then ERC-1271 against the multisig with empty signature,
+        // which routes through the `signedMessages` path we just populated
+        bytes memory setCall = abi.encodeCall(IIdentityRegistryBridger.setAgentWallet, (deadline, ""));
+        _execSafeTx(_safe, _signerPk, IDENTITY_REGISTRY_BRIDGER_PROXY, 0, setCall, Enum.Operation.Call);
+
+        _agentInstance; // silence unused-parameter warning; agent address is implicit in _signerPk
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers for SignMessageLib + EIP-712 typed-data construction
+    // -----------------------------------------------------------------------
+
+    bytes32 internal constant AGENT_WALLET_SET_TYPEHASH =
+        keccak256("AgentWalletSet(uint256 agentId,address newWallet,address owner,uint256 deadline)");
+    bytes32 internal constant SAFE_MSG_TYPEHASH =
+        0x60b3cbf8b4a223d68d641b3b6ddf9a298e7f33710cf3d3a9d1146b5a6150fbca;
+
+    /// @dev Builds the IdentityRegistry's `AgentWalletSet` EIP-712 digest using its on-chain domain.
+    function _agentWalletSetDigest(uint256 _agentId, address _newWallet, address _agentOwner, uint256 _deadline)
+        internal view returns (bytes32)
+    {
+        (, string memory name, string memory version, uint256 chainId, address verifyingContract, ,) =
+            IIdentityRegistry(IDENTITY_REGISTRY).eip712Domain();
+        bytes32 domainSeparator = keccak256(abi.encode(
+            keccak256("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)"),
+            keccak256(bytes(name)), keccak256(bytes(version)), chainId, verifyingContract
+        ));
+        bytes32 structHash = keccak256(abi.encode(
+            AGENT_WALLET_SET_TYPEHASH, _agentId, _newWallet, _agentOwner, _deadline
+        ));
+        return keccak256(abi.encodePacked(bytes1(0x19), bytes1(0x01), domainSeparator, structHash));
+    }
+
+    /// @dev Mirrors `CompatibilityFallbackHandler.getMessageHashForSafe`: the wrapped Safe-side hash that
+    ///      `signMessage` stores and `isValidSignature` looks up.
+    function _safeMessageHash(address _safe, bytes32 _digest) internal view returns (bytes32) {
+        bytes32 safeMessageHash = keccak256(abi.encode(SAFE_MSG_TYPEHASH, keccak256(abi.encodePacked(_digest))));
+        return keccak256(abi.encodePacked(
+            bytes1(0x19), bytes1(0x01), GnosisSafe(payable(_safe)).domainSeparator(), safeMessageHash
+        ));
+    }
+
+    /// @dev Executes a single-owner Safe transaction signed by `_signerPk` using ECDSA. Mirrors the pattern in
+    ///      `RecoverFunds.t.sol`.
+    function _execSafeTx(
+        GnosisSafe _safe,
+        uint256 _signerPk,
+        address _to,
+        uint256 _value,
+        bytes memory _data,
+        Enum.Operation _operation
+    ) internal {
+        uint256 nonce = _safe.nonce();
+        bytes32 txHash = _safe.getTransactionHash(
+            _to, _value, _data, _operation, 0, 0, 0, address(0), payable(address(0)), nonce
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(_signerPk, txHash);
+        bytes memory signature = abi.encodePacked(r, s, v);
+        vm.prank(vm.addr(_signerPk));
+        _safe.execTransaction{value: _value}(
+            _to, _value, _data, _operation, 0, 0, 0, address(0), payable(address(0)), signature
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Implements the corrected Design C from `clob_v2_deposit_wallet_creator_plan.md` (the planning PR this targets). New `SafeAndDepositWalletCreator` deploys a Safe (governance + RecoveryModule + ERC-8004 agent wallet) and links it to a pre-deployed Polymarket deposit wallet (CLOB-tradable trading account) — the migration path for new accounts under the CLOB v2 rollout, since fresh PolySafes are now CLOB-rejected at the API ingest layer.

- **Single on-chain user transaction** (`ServiceManager.deploy → creator.create`): atomically deploys the Safe with RecoveryModule enabled (via `Safe.setup`) and verifies a deposit wallet pre-deployed off-chain by Polymarket's relayer (`DepositWalletFactory.deploy` is `onlyOperator`-gated; no on-chain meta-tx variant). The link is recorded in `mapMultisigDepositWallets` and emitted via `DepositWalletLinked`.
- **Off-chain HTTP unconstrained**: Pearl predicts the deposit wallet address from the agent-instance EOA, fires the relayer call, and submits the on-chain deploy. Phase 4 (post-deploy session-signer + approvals batch via `factory.proxy`) is also off-chain.
- **Independent peers topology**: the Safe and the deposit wallet are bridged by the agent-instance EOA — the EOA is one of the Safe's owners and the deposit wallet's sole owner. The Safe cannot own the deposit wallet because Polymarket's `_erc1271IsValidSignatureNowCalldata` is pure ECDSA (deliberately so per Sourcify-verified source).
- **ERC-8004 `setAgentWallet` works through the new Safe** via the standard `SignMessageLib` + `CompatibilityFallbackHandler` path. No special multisig logic is required — the existing PolySafe creator doesn't port any either; it's pure Safe v1.3.0 machinery. The Safe just needs the canonical `CompatibilityFallbackHandler` (`0xf48f2B2d2a534e402487b3ee7C18c33Aec0Fe5e4`) passed in via `data`.

## Files

- `contracts/multisigs/SafeAndDepositWalletCreator.sol` — new creator (~140 LoC)
- `contracts/test/MockDepositWalletFactory.sol` — minimal mock for unit tests (~60 LoC)
- `test/SafeAndDepositWalletCreator.t.sol` — 12 unit tests (~290 LoC)
- `test/SafeAndDepositWalletCreatorFork.sol` — 3 fork tests + 2 e2e fork tests (~480 LoC)
- `clob_v2_deposit_wallet_creator_plan.md` — added "Design lock-in 2026-05-10" section
- `CLAUDE.md` — listed the new contract under Multisig Implementations + new section on the CLOB v2 deposit-wallet flow + new test commands
- `README.md` — listed the new contract + new test commands

## Design choices worth flagging for review

- **No on-chain bytecode hash check.** Polymarket's wallets use Solady's `deployDeterministicERC1967WithImmutableArgs`, which bakes per-wallet immutable args (factory, walletId) into the proxy bytecode — so each wallet has a distinct runtime codehash. Defense rests on `code.length > 0` plus `IDepositWallet.owner()` returning the expected agent EOA; CREATE2 collisions are infeasible without controlling the factory. Documented in NatSpec.
- **`owners.length == 1`** enforced (single agent-instance EOA = bridge to the DW's sole owner).
- **Recovery weakness for DW funds defused by Privy custody** of the agent EOA — confirmed in the plan's "Design lock-in 2026-05-10" section.
- **Front-running** acknowledged but not blocking (factory's CREATE2 collision-revert + Pearl-internal EOA address).

## Test plan

- [x] Unit tests pass: `forge test --match-contract SafeAndDepositWalletCreator -vvv` (12/12)
- [x] Fork tests pass: `forge test -f $POLYGON_RPC --match-contract SafeAndDepositWalletCreatorFork -vvv` (3/3)
- [x] E2e fork tests pass: `forge test -f $POLYGON_RPC --match-contract SafeAndDepositWalletCreatorE2E -vvv` (2/2)
  - `testForkE2E_FullWorkflow` — full Phase 1 + 2 + 3 workflow against real `ServiceManager` / `ServiceRegistryL2` / `IdentityRegistryBridger` on a Polygon fork
  - `testForkE2E_SetAgentWalletViaSignMessageLib` — proves the multisig can register itself as the ERC-8004 agent wallet using the standard SignMessageLib + CompatibilityFallbackHandler path
- [ ] Existing `PolySafeCreator` tests still pass (no regressions)
- [ ] Governance proposal to whitelist the creator on Polygon's `ServiceRegistryL2.mapMultisigs` (deferred to a follow-up)
- [ ] Deployment scripts (`scripts/deployment/l2/deploy_NN_safe_and_dw_creator.sh`) — deferred to a follow-up