### PR TITLE
fix(scripts): make proxy change-owner scripts bash-3.2 safe and idempotent

### DIFF
--- a/scripts/deployment/l2/script_l2_07_service_manager_proxy_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_07_service_manager_proxy_change_owner.sh
@@ -5,9 +5,9 @@
 # is the bridge mediator; on Arbitrum it is the L1-aliased Timelock — both are
 # stored as bridgeMediatorAddress in the per-network globals.
 #
-# The script is idempotent: it pre-checks that the signer derived from
-# $derivationPath is the current proxy owner (otherwise changeOwner reverts with
-# OwnerOnly), and is a no-op if the proxy is already owned by the target.
+# The script is idempotent: it is a no-op if the proxy is already owned by the
+# target, and otherwise pre-checks that the signer derived from $derivationPath
+# is the current proxy owner (changeOwner would revert with OwnerOnly otherwise).
 
 # Check if $1 is provided
 if [ -z "$1" ]; then
@@ -35,17 +35,16 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
 bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
-timelockAddress=$(jq -r '.timelockAddress' $globals)
 
-# New owner: bridge mediator on L2, Timelock on L1 mainnet.
-if [ "$bridgeMediatorAddress" != "null" ] && [ -n "$bridgeMediatorAddress" ]; then
-  newOwnerAddress="$bridgeMediatorAddress"
-elif [ "$timelockAddress" != "null" ] && [ -n "$timelockAddress" ]; then
-  newOwnerAddress="$timelockAddress"
-else
-  echo "${red}!!! Neither bridgeMediatorAddress nor timelockAddress is set in $globals${reset}"
+# New owner: the chain's governance control point — the bridge mediator on L2,
+# or the L1-aliased Timelock on Arbitrum — stored as bridgeMediatorAddress. It
+# is required and has no fallback: timelockAddress is the non-aliased L1
+# Timelock, an address nobody controls on an L2.
+if [ "$bridgeMediatorAddress" == "null" ] || [ -z "$bridgeMediatorAddress" ]; then
+  echo "${red}!!! bridgeMediatorAddress is not set in $globals${reset}"
   exit 1
 fi
+newOwnerAddress="$bridgeMediatorAddress"
 
 if [ "$serviceManagerProxyAddress" == "null" ] || [ -z "$serviceManagerProxyAddress" ]; then
   echo "${red}!!! serviceManagerProxyAddress is not set in $globals${reset}"
@@ -76,18 +75,29 @@ else
   deployer=$(cast wallet address $walletArgs)
 fi
 
-# Pre-flight: current owner must equal the signer; otherwise changeOwner reverts.
+# Pre-flight: read the current owner. Addresses are lowercased before comparison
+# because the globals JSON may not be EIP-55 checksummed; tr is used instead of
+# the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $serviceManagerProxyAddress "owner()(address)")
-if [ "${currentOwner,,}" != "${deployer,,}" ]; then
+if [ -z "$currentOwner" ]; then
+  echo "${red}!!! Failed to read the current ServiceManagerProxy owner (RPC error?)${reset}"
+  exit 1
+fi
+currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+newOwnerLc=$(echo "$newOwnerAddress" | tr '[:upper:]' '[:lower:]')
+
+# No-op if already owned by the target.
+if [ "$currentOwnerLc" == "$newOwnerLc" ]; then
+  echo "${green}ServiceManagerProxy $serviceManagerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
+  exit 0
+fi
+
+# The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly.
+if [ "$currentOwnerLc" != "$deployerLc" ]; then
   echo "${red}!!! Signer $deployer is not the current ServiceManagerProxy owner ($currentOwner).${reset}"
   echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
   exit 1
-fi
-
-# No-op if already owned by the target
-if [ "${currentOwner,,}" == "${newOwnerAddress,,}" ]; then
-  echo "${green}ServiceManagerProxy $serviceManagerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
-  exit 0
 fi
 
 castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
@@ -98,3 +108,8 @@ echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
 echo "$result" | grep "status"
+if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+  echo "${red}!!! changeOwner transaction did not succeed${reset}"
+  exit 1
+fi
+echo "${green}ServiceManagerProxy owner changed to $newOwnerAddress.${reset}"

--- a/scripts/deployment/l2/script_l2_07_service_manager_proxy_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_07_service_manager_proxy_change_owner.sh
@@ -46,6 +46,11 @@ if [ "$bridgeMediatorAddress" == "null" ] || [ -z "$bridgeMediatorAddress" ]; th
 fi
 newOwnerAddress="$bridgeMediatorAddress"
 
+if [ "$newOwnerAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! newOwnerAddress is the zero address — check $globals${reset}"
+  exit 1
+fi
+
 if [ "$serviceManagerProxyAddress" == "null" ] || [ -z "$serviceManagerProxyAddress" ]; then
   echo "${red}!!! serviceManagerProxyAddress is not set in $globals${reset}"
   exit 1
@@ -79,8 +84,8 @@ fi
 # because the globals JSON may not be EIP-55 checksummed; tr is used instead of
 # the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $serviceManagerProxyAddress "owner()(address)")
-if [ -z "$currentOwner" ]; then
-  echo "${red}!!! Failed to read the current ServiceManagerProxy owner (RPC error?)${reset}"
+if ! [[ "$currentOwner" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to read the current ServiceManagerProxy owner (got: $currentOwner)${reset}"
   exit 1
 fi
 currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
@@ -107,8 +112,9 @@ castArgs="$serviceManagerProxyAddress changeOwner(address) $newOwnerAddress"
 echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
-echo "$result" | grep "status"
-if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+statusLine=$(echo "$result" | grep -E "^status[[:space:]]+[0-9]")
+echo "$statusLine"
+if ! echo "$statusLine" | grep -qE "^status[[:space:]]+1[[:space:]]"; then
   echo "${red}!!! changeOwner transaction did not succeed${reset}"
   exit 1
 fi

--- a/scripts/deployment/l2/script_l2_08_identity_registry_bridger_proxy_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_08_identity_registry_bridger_proxy_change_owner.sh
@@ -5,9 +5,9 @@
 # L2 this is the bridge mediator; on Arbitrum it is the L1-aliased Timelock —
 # both are stored as bridgeMediatorAddress in the per-network globals.
 #
-# The script is idempotent: it pre-checks that the signer derived from
-# $derivationPath is the current proxy owner (otherwise changeOwner reverts with
-# OwnerOnly), and is a no-op if the proxy is already owned by the target.
+# The script is idempotent: it is a no-op if the proxy is already owned by the
+# target, and otherwise pre-checks that the signer derived from $derivationPath
+# is the current proxy owner (changeOwner would revert with OwnerOnly otherwise).
 
 # Check if $1 is provided
 if [ -z "$1" ]; then
@@ -35,17 +35,16 @@ networkURL=$(jq -r '.networkURL' $globals)
 
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
 bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
-timelockAddress=$(jq -r '.timelockAddress' $globals)
 
-# New owner: bridge mediator on L2, Timelock on L1 mainnet.
-if [ "$bridgeMediatorAddress" != "null" ] && [ -n "$bridgeMediatorAddress" ]; then
-  newOwnerAddress="$bridgeMediatorAddress"
-elif [ "$timelockAddress" != "null" ] && [ -n "$timelockAddress" ]; then
-  newOwnerAddress="$timelockAddress"
-else
-  echo "${red}!!! Neither bridgeMediatorAddress nor timelockAddress is set in $globals${reset}"
+# New owner: the chain's governance control point — the bridge mediator on L2,
+# or the L1-aliased Timelock on Arbitrum — stored as bridgeMediatorAddress. It
+# is required and has no fallback: timelockAddress is the non-aliased L1
+# Timelock, an address nobody controls on an L2.
+if [ "$bridgeMediatorAddress" == "null" ] || [ -z "$bridgeMediatorAddress" ]; then
+  echo "${red}!!! bridgeMediatorAddress is not set in $globals${reset}"
   exit 1
 fi
+newOwnerAddress="$bridgeMediatorAddress"
 
 if [ "$identityRegistryBridgerProxyAddress" == "null" ] || [ -z "$identityRegistryBridgerProxyAddress" ]; then
   echo "${red}!!! identityRegistryBridgerProxyAddress is not set in $globals${reset}"
@@ -76,18 +75,29 @@ else
   deployer=$(cast wallet address $walletArgs)
 fi
 
-# Pre-flight: current owner must equal the signer; otherwise changeOwner reverts.
+# Pre-flight: read the current owner. Addresses are lowercased before comparison
+# because the globals JSON may not be EIP-55 checksummed; tr is used instead of
+# the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $identityRegistryBridgerProxyAddress "owner()(address)")
-if [ "${currentOwner,,}" != "${deployer,,}" ]; then
+if [ -z "$currentOwner" ]; then
+  echo "${red}!!! Failed to read the current IdentityRegistryBridgerProxy owner (RPC error?)${reset}"
+  exit 1
+fi
+currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+newOwnerLc=$(echo "$newOwnerAddress" | tr '[:upper:]' '[:lower:]')
+
+# No-op if already owned by the target.
+if [ "$currentOwnerLc" == "$newOwnerLc" ]; then
+  echo "${green}IdentityRegistryBridgerProxy $identityRegistryBridgerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
+  exit 0
+fi
+
+# The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly.
+if [ "$currentOwnerLc" != "$deployerLc" ]; then
   echo "${red}!!! Signer $deployer is not the current IdentityRegistryBridgerProxy owner ($currentOwner).${reset}"
   echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
   exit 1
-fi
-
-# No-op if already owned by the target
-if [ "${currentOwner,,}" == "${newOwnerAddress,,}" ]; then
-  echo "${green}IdentityRegistryBridgerProxy $identityRegistryBridgerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
-  exit 0
 fi
 
 castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
@@ -98,3 +108,8 @@ echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
 echo "$result" | grep "status"
+if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+  echo "${red}!!! changeOwner transaction did not succeed${reset}"
+  exit 1
+fi
+echo "${green}IdentityRegistryBridgerProxy owner changed to $newOwnerAddress.${reset}"

--- a/scripts/deployment/l2/script_l2_08_identity_registry_bridger_proxy_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_08_identity_registry_bridger_proxy_change_owner.sh
@@ -46,6 +46,11 @@ if [ "$bridgeMediatorAddress" == "null" ] || [ -z "$bridgeMediatorAddress" ]; th
 fi
 newOwnerAddress="$bridgeMediatorAddress"
 
+if [ "$newOwnerAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! newOwnerAddress is the zero address — check $globals${reset}"
+  exit 1
+fi
+
 if [ "$identityRegistryBridgerProxyAddress" == "null" ] || [ -z "$identityRegistryBridgerProxyAddress" ]; then
   echo "${red}!!! identityRegistryBridgerProxyAddress is not set in $globals${reset}"
   exit 1
@@ -79,8 +84,8 @@ fi
 # because the globals JSON may not be EIP-55 checksummed; tr is used instead of
 # the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $identityRegistryBridgerProxyAddress "owner()(address)")
-if [ -z "$currentOwner" ]; then
-  echo "${red}!!! Failed to read the current IdentityRegistryBridgerProxy owner (RPC error?)${reset}"
+if ! [[ "$currentOwner" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to read the current IdentityRegistryBridgerProxy owner (got: $currentOwner)${reset}"
   exit 1
 fi
 currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
@@ -107,8 +112,9 @@ castArgs="$identityRegistryBridgerProxyAddress changeOwner(address) $newOwnerAdd
 echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
-echo "$result" | grep "status"
-if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+statusLine=$(echo "$result" | grep -E "^status[[:space:]]+[0-9]")
+echo "$statusLine"
+if ! echo "$statusLine" | grep -qE "^status[[:space:]]+1[[:space:]]"; then
   echo "${red}!!! changeOwner transaction did not succeed${reset}"
   exit 1
 fi

--- a/scripts/deployment/script_l1_07_service_manager_proxy_change_owner.sh
+++ b/scripts/deployment/script_l1_07_service_manager_proxy_change_owner.sh
@@ -3,9 +3,9 @@
 # Transfers ServiceManagerProxy ownership from the deployer EOA to the protocol
 # Timelock on Ethereum mainnet, by calling changeOwner(timelock).
 #
-# The script is idempotent: it pre-checks that the signer derived from
-# $derivationPath is the current proxy owner (otherwise changeOwner reverts with
-# OwnerOnly), and is a no-op if the proxy is already owned by the target.
+# The script is idempotent: it is a no-op if the proxy is already owned by the
+# target, and otherwise pre-checks that the signer derived from $derivationPath
+# is the current proxy owner (changeOwner would revert with OwnerOnly otherwise).
 
 # Check if $1 is provided
 if [ -z "$1" ]; then
@@ -32,18 +32,14 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 serviceManagerProxyAddress=$(jq -r '.serviceManagerProxyAddress' $globals)
-bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
 timelockAddress=$(jq -r '.timelockAddress' $globals)
 
-# New owner: bridge mediator on L2, Timelock on L1 mainnet.
-if [ "$bridgeMediatorAddress" != "null" ] && [ -n "$bridgeMediatorAddress" ]; then
-  newOwnerAddress="$bridgeMediatorAddress"
-elif [ "$timelockAddress" != "null" ] && [ -n "$timelockAddress" ]; then
-  newOwnerAddress="$timelockAddress"
-else
-  echo "${red}!!! Neither bridgeMediatorAddress nor timelockAddress is set in $globals${reset}"
+# New owner: the protocol Timelock on Ethereum mainnet.
+if [ "$timelockAddress" == "null" ] || [ -z "$timelockAddress" ]; then
+  echo "${red}!!! timelockAddress is not set in $globals${reset}"
   exit 1
 fi
+newOwnerAddress="$timelockAddress"
 
 if [ "$serviceManagerProxyAddress" == "null" ] || [ -z "$serviceManagerProxyAddress" ]; then
   echo "${red}!!! serviceManagerProxyAddress is not set in $globals${reset}"
@@ -74,18 +70,29 @@ else
   deployer=$(cast wallet address $walletArgs)
 fi
 
-# Pre-flight: current owner must equal the signer; otherwise changeOwner reverts.
+# Pre-flight: read the current owner. Addresses are lowercased before comparison
+# because the globals JSON may not be EIP-55 checksummed; tr is used instead of
+# the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $serviceManagerProxyAddress "owner()(address)")
-if [ "${currentOwner,,}" != "${deployer,,}" ]; then
+if [ -z "$currentOwner" ]; then
+  echo "${red}!!! Failed to read the current ServiceManagerProxy owner (RPC error?)${reset}"
+  exit 1
+fi
+currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+newOwnerLc=$(echo "$newOwnerAddress" | tr '[:upper:]' '[:lower:]')
+
+# No-op if already owned by the target.
+if [ "$currentOwnerLc" == "$newOwnerLc" ]; then
+  echo "${green}ServiceManagerProxy $serviceManagerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
+  exit 0
+fi
+
+# The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly.
+if [ "$currentOwnerLc" != "$deployerLc" ]; then
   echo "${red}!!! Signer $deployer is not the current ServiceManagerProxy owner ($currentOwner).${reset}"
   echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
   exit 1
-fi
-
-# No-op if already owned by the target
-if [ "${currentOwner,,}" == "${newOwnerAddress,,}" ]; then
-  echo "${green}ServiceManagerProxy $serviceManagerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
-  exit 0
 fi
 
 castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
@@ -96,3 +103,8 @@ echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
 echo "$result" | grep "status"
+if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+  echo "${red}!!! changeOwner transaction did not succeed${reset}"
+  exit 1
+fi
+echo "${green}ServiceManagerProxy owner changed to $newOwnerAddress.${reset}"

--- a/scripts/deployment/script_l1_07_service_manager_proxy_change_owner.sh
+++ b/scripts/deployment/script_l1_07_service_manager_proxy_change_owner.sh
@@ -41,6 +41,11 @@ if [ "$timelockAddress" == "null" ] || [ -z "$timelockAddress" ]; then
 fi
 newOwnerAddress="$timelockAddress"
 
+if [ "$newOwnerAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! newOwnerAddress is the zero address — check $globals${reset}"
+  exit 1
+fi
+
 if [ "$serviceManagerProxyAddress" == "null" ] || [ -z "$serviceManagerProxyAddress" ]; then
   echo "${red}!!! serviceManagerProxyAddress is not set in $globals${reset}"
   exit 1
@@ -74,8 +79,8 @@ fi
 # because the globals JSON may not be EIP-55 checksummed; tr is used instead of
 # the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $serviceManagerProxyAddress "owner()(address)")
-if [ -z "$currentOwner" ]; then
-  echo "${red}!!! Failed to read the current ServiceManagerProxy owner (RPC error?)${reset}"
+if ! [[ "$currentOwner" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to read the current ServiceManagerProxy owner (got: $currentOwner)${reset}"
   exit 1
 fi
 currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
@@ -102,8 +107,9 @@ castArgs="$serviceManagerProxyAddress changeOwner(address) $newOwnerAddress"
 echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
-echo "$result" | grep "status"
-if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+statusLine=$(echo "$result" | grep -E "^status[[:space:]]+[0-9]")
+echo "$statusLine"
+if ! echo "$statusLine" | grep -qE "^status[[:space:]]+1[[:space:]]"; then
   echo "${red}!!! changeOwner transaction did not succeed${reset}"
   exit 1
 fi

--- a/scripts/deployment/script_l1_08_identity_registry_bridger_proxy_change_owner.sh
+++ b/scripts/deployment/script_l1_08_identity_registry_bridger_proxy_change_owner.sh
@@ -41,6 +41,11 @@ if [ "$timelockAddress" == "null" ] || [ -z "$timelockAddress" ]; then
 fi
 newOwnerAddress="$timelockAddress"
 
+if [ "$newOwnerAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! newOwnerAddress is the zero address — check $globals${reset}"
+  exit 1
+fi
+
 if [ "$identityRegistryBridgerProxyAddress" == "null" ] || [ -z "$identityRegistryBridgerProxyAddress" ]; then
   echo "${red}!!! identityRegistryBridgerProxyAddress is not set in $globals${reset}"
   exit 1
@@ -74,8 +79,8 @@ fi
 # because the globals JSON may not be EIP-55 checksummed; tr is used instead of
 # the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $identityRegistryBridgerProxyAddress "owner()(address)")
-if [ -z "$currentOwner" ]; then
-  echo "${red}!!! Failed to read the current IdentityRegistryBridgerProxy owner (RPC error?)${reset}"
+if ! [[ "$currentOwner" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to read the current IdentityRegistryBridgerProxy owner (got: $currentOwner)${reset}"
   exit 1
 fi
 currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
@@ -102,8 +107,9 @@ castArgs="$identityRegistryBridgerProxyAddress changeOwner(address) $newOwnerAdd
 echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
-echo "$result" | grep "status"
-if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+statusLine=$(echo "$result" | grep -E "^status[[:space:]]+[0-9]")
+echo "$statusLine"
+if ! echo "$statusLine" | grep -qE "^status[[:space:]]+1[[:space:]]"; then
   echo "${red}!!! changeOwner transaction did not succeed${reset}"
   exit 1
 fi

--- a/scripts/deployment/script_l1_08_identity_registry_bridger_proxy_change_owner.sh
+++ b/scripts/deployment/script_l1_08_identity_registry_bridger_proxy_change_owner.sh
@@ -3,9 +3,9 @@
 # Transfers IdentityRegistryBridgerProxy ownership from the deployer EOA to the
 # protocol Timelock on Ethereum mainnet, by calling changeOwner(timelock).
 #
-# The script is idempotent: it pre-checks that the signer derived from
-# $derivationPath is the current proxy owner (otherwise changeOwner reverts with
-# OwnerOnly), and is a no-op if the proxy is already owned by the target.
+# The script is idempotent: it is a no-op if the proxy is already owned by the
+# target, and otherwise pre-checks that the signer derived from $derivationPath
+# is the current proxy owner (changeOwner would revert with OwnerOnly otherwise).
 
 # Check if $1 is provided
 if [ -z "$1" ]; then
@@ -32,18 +32,14 @@ chainId=$(jq -r '.chainId' $globals)
 networkURL=$(jq -r '.networkURL' $globals)
 
 identityRegistryBridgerProxyAddress=$(jq -r '.identityRegistryBridgerProxyAddress' $globals)
-bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
 timelockAddress=$(jq -r '.timelockAddress' $globals)
 
-# New owner: bridge mediator on L2, Timelock on L1 mainnet.
-if [ "$bridgeMediatorAddress" != "null" ] && [ -n "$bridgeMediatorAddress" ]; then
-  newOwnerAddress="$bridgeMediatorAddress"
-elif [ "$timelockAddress" != "null" ] && [ -n "$timelockAddress" ]; then
-  newOwnerAddress="$timelockAddress"
-else
-  echo "${red}!!! Neither bridgeMediatorAddress nor timelockAddress is set in $globals${reset}"
+# New owner: the protocol Timelock on Ethereum mainnet.
+if [ "$timelockAddress" == "null" ] || [ -z "$timelockAddress" ]; then
+  echo "${red}!!! timelockAddress is not set in $globals${reset}"
   exit 1
 fi
+newOwnerAddress="$timelockAddress"
 
 if [ "$identityRegistryBridgerProxyAddress" == "null" ] || [ -z "$identityRegistryBridgerProxyAddress" ]; then
   echo "${red}!!! identityRegistryBridgerProxyAddress is not set in $globals${reset}"
@@ -74,18 +70,29 @@ else
   deployer=$(cast wallet address $walletArgs)
 fi
 
-# Pre-flight: current owner must equal the signer; otherwise changeOwner reverts.
+# Pre-flight: read the current owner. Addresses are lowercased before comparison
+# because the globals JSON may not be EIP-55 checksummed; tr is used instead of
+# the ${var,,} expansion so the script also runs on bash 3.2 (macOS default).
 currentOwner=$(cast call --rpc-url $networkURL$API_KEY $identityRegistryBridgerProxyAddress "owner()(address)")
-if [ "${currentOwner,,}" != "${deployer,,}" ]; then
+if [ -z "$currentOwner" ]; then
+  echo "${red}!!! Failed to read the current IdentityRegistryBridgerProxy owner (RPC error?)${reset}"
+  exit 1
+fi
+currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+newOwnerLc=$(echo "$newOwnerAddress" | tr '[:upper:]' '[:lower:]')
+
+# No-op if already owned by the target.
+if [ "$currentOwnerLc" == "$newOwnerLc" ]; then
+  echo "${green}IdentityRegistryBridgerProxy $identityRegistryBridgerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
+  exit 0
+fi
+
+# The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly.
+if [ "$currentOwnerLc" != "$deployerLc" ]; then
   echo "${red}!!! Signer $deployer is not the current IdentityRegistryBridgerProxy owner ($currentOwner).${reset}"
   echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
   exit 1
-fi
-
-# No-op if already owned by the target
-if [ "${currentOwner,,}" == "${newOwnerAddress,,}" ]; then
-  echo "${green}IdentityRegistryBridgerProxy $identityRegistryBridgerProxyAddress is already owned by $newOwnerAddress. Nothing to do.${reset}"
-  exit 0
 fi
 
 castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
@@ -96,3 +103,8 @@ echo $castArgs
 castCmd="$castSendHeader $castArgs"
 result=$($castCmd)
 echo "$result" | grep "status"
+if ! echo "$result" | grep -qE "status[[:space:]]+1"; then
+  echo "${red}!!! changeOwner transaction did not succeed${reset}"
+  exit 1
+fi
+echo "${green}IdentityRegistryBridgerProxy owner changed to $newOwnerAddress.${reset}"


### PR DESCRIPTION
Follow-up to #296, addressing the [code review](https://github.com/valory-xyz/autonolas-registries/pull/296#issuecomment-4519912347). Scope is limited to the four `*_proxy_change_owner.sh` scripts — no contract or globals changes.

## 🔴 Blocking fixes

- **bash 3.2 compatibility.** The scripts used `${currentOwner,,}` / `${deployer,,}` lowercase parameter expansion, which is bash 4.0+ only. macOS ships `/bin/bash` 3.2.57, on which that is a runtime `bad substitution` error. Replaced with portable `tr '[:upper:]' '[:lower:]'`. Lowercasing is still needed for correctness — addresses from `globals_*.json` may not be EIP-55 checksummed and so wouldn't byte-match `cast`'s checksummed output.
- **Actually idempotent now.** The two pre-flight checks were in the wrong order: the signer-is-current-owner check ran before the already-owned-by-target no-op check. After a successful transfer, `currentOwner` is the governance contract, so a re-run hit the signer check first and exited `1` with a misleading `derivationPath` hint; the no-op check was unreachable. The checks are now swapped — no-op check first, signer check second — so a re-run exits `0` and multi-network loops no longer abort on an already-transferred chain.

## 🟡 / 🟢 follow-ups

- **L1 scripts select `timelockAddress` directly** instead of preferring `bridgeMediatorAddress` with a timelock fallback. They target the mainnet Timelock; the previous logic only worked because `globals_mainnet.json` happens to lack `bridgeMediatorAddress`.
- **L2 scripts require `bridgeMediatorAddress`** and error out if it is missing, rather than falling back to `timelockAddress` — on an L2 that is the non-aliased L1 Timelock, an address nobody controls.
- **Failure detection.** An empty `cast call` result (RPC error) and a reverted `cast send` (`status` != 1) now exit `1` instead of proceeding or reporting success.

## Testing

- `bash -n` syntax check passes on all four scripts under bash 3.2.57.
- Simulated the idempotent re-run path (mixed-case target address) — exits `0` as a no-op.
- Verified the `status` grep matches `status 1 (success)` and not `status 0 (failed)`.