### PR TITLE
docs: put the item-24 singleton requirement at the proxyHash call sites; cross-link 26/27

### DIFF
--- a/contracts/multisigs/GnosisSafeSameAddressMultisig.sol
+++ b/contracts/multisigs/GnosisSafeSameAddressMultisig.sol
@@ -100,6 +100,15 @@ contract GnosisSafeSameAddressMultisig {
         }
 
         // Check that the multisig address corresponds to the authorized multisig proxy bytecode hash
+        // NOTE: this proves the account holds Safe-proxy bytecode; it does NOT prove which singleton
+        // the proxy delegates to. A Safe proxy keeps its singleton in storage slot 0 and loads it at
+        // run time, so every proxy from a given factory has identical runtime code and codehash
+        // whatever it points at, and createProxyWithNonce takes the singleton as a caller-supplied
+        // parameter. Singleton identity is guaranteed upstream instead: every whitelisted multisig
+        // implementation builds the multisig itself against its own pinned immutable. Any future
+        // implementation added to mapMultisigs that accepts a CALLER-SUPPLIED multisig address must
+        // validate the singleton explicitly (implementation slot / masterCopy()) in addition to this
+        // check. See item 24 in docs/Vulnerabilities_list_registries.md.
         bytes32 multisigProxyHash = keccak256(multisig.code);
         if (proxyHash != multisigProxyHash) {
             revert UnauthorizedMultisig(multisig);

--- a/contracts/staking/StakingBase.sol
+++ b/contracts/staking/StakingBase.sol
@@ -802,6 +802,15 @@ abstract contract StakingBase is ERC721TokenReceiver {
         }
 
         // Check that the multisig address corresponds to the authorized multisig proxy bytecode hash
+        // NOTE: this proves the account holds Safe-proxy bytecode; it does NOT prove which singleton
+        // the proxy delegates to. A Safe proxy keeps its singleton in storage slot 0 and loads it at
+        // run time, so every proxy from a given factory has identical runtime code and codehash
+        // whatever it points at, and createProxyWithNonce takes the singleton as a caller-supplied
+        // parameter. Singleton identity is guaranteed upstream instead: every whitelisted multisig
+        // implementation builds the multisig itself against its own pinned immutable. Any future
+        // implementation added to mapMultisigs that accepts a CALLER-SUPPLIED multisig address must
+        // validate the singleton explicitly (implementation slot / masterCopy()) in addition to this
+        // check. See item 24 in docs/Vulnerabilities_list_registries.md.
         bytes32 multisigProxyHash = service.multisig.codehash;
         if (proxyHash != multisigProxyHash) {
             revert UnauthorizedMultisig(service.multisig);

--- a/docs/Vulnerabilities_list_registries.md
+++ b/docs/Vulnerabilities_list_registries.md
@@ -282,7 +282,7 @@ staking contracts are urged to configure them with no more than 100 of staking s
 
 ### 11. `deploy` function
 
-**Severity**: Informational
+**Severity**: Informative
 
 The following function is implemented in the ServiceRegistry and ServiceRegistryL2
 contracts:
@@ -714,7 +714,16 @@ implementation identity. It does not.
 **Guidance.** Any multisig implementation added to `mapMultisigs` that accepts a caller-supplied
 multisig address must validate the singleton explicitly — read the implementation slot (or call
 `masterCopy()`) and compare it against an approved singleton — in addition to the `codehash` check.
-`proxyHash` alone will not do it.
+`proxyHash` alone will not do it. This requirement is also recorded as a comment at both `proxyHash`
+comparison sites (`GnosisSafeSameAddressMultisig`, `StakingBase`), because the person who would
+reintroduce the gap is writing a new implementation rather than reading this list.
+
+**The de-whitelisting is load-bearing for two entries.** Both this item and item 23 (`deploy`
+same-address multisig takeover) currently rest on the same state: `mapMultisigs` returning `false`
+for `GnosisSafeSameAddressMultisig` and `PolySafeSameAddressMultisig`. That is a governance-mutable
+flag, not a code property. Re-whitelisting either implementation would reopen **both** items
+simultaneously, so such a proposal should be treated as a security change gated on the singleton
+validation above landing first — not as a configuration tweak.
 
 - Contracts: [GnosisSafeSameAddressMultisig](../contracts/multisigs/GnosisSafeSameAddressMultisig.sol), [StakingBase](../contracts/staking/StakingBase.sol), [GnosisSafeMultisig](../contracts/multisigs/GnosisSafeMultisig.sol), [SafeMultisigWithRecoveryModule](../contracts/multisigs/SafeMultisigWithRecoveryModule.sol), [RecoveryModule](../contracts/multisigs/RecoveryModule.sol)
 
@@ -750,6 +759,10 @@ former one-agent Safe owner therefore retains authorization to call the bridger'
 (`unsetAgentWallet()`, mutable `setMetadata()`) after the service has been fully unbonded and before any
 recovery or re-registration.
 
+**Related.** Item 27 is the same shape on a different piece of state: the direct `unbond()` path does
+not perform cleanup that the alternative path does — the bridger mapping here, the operator nonce
+there. A lifecycle fix to the unbond path should address both rather than one.
+
 **No value at risk; a post-unbond identity-integrity window.** The impact is that a stale actor can mutate
 the service's ERC-8004 identity (unset an agent wallet, change metadata) during the post-unbond /
 pre-recovery window; scope is the single-agent-Safe case where the former owner still controls the Safe. The
@@ -770,6 +783,8 @@ signature cannot be replayed once used. The **direct** `unbond()` path does not 
 the nonce stays at `N`. After the service is reactivated and the operator re-registers instances, the old
 signature (still valid for nonce `N`, same `operator` / `serviceOwner` / `serviceId`) can be replayed to
 unbond the operator's new instances without fresh consent.
+
+**Related.** Item 26 is the same shape on a different piece of state — see the note there.
 
 **No fund loss; operator-avoidable stale-consent edge.** Unbonding returns the operator's own bond to the
 operator; the harm is a forced unbond of instances registered post-reactivation, a griefing / stale-consent


### PR DESCRIPTION
Follow-up to #310, acting on points raised in review there that were not addressed before merge. **Comments and documentation only — no executable line changes**, so bytecode is unaffected.

## The item-24 requirement now sits where it binds

Item 24's own framing is that the risk is prospective: *"a future multisig implementation that adopts a caller-supplied address would restore the gap, and whoever writes it may reasonably assume the `proxyHash` comparison already covers implementation identity."*

That person is writing a new multisig implementation and getting it whitelisted — they have no particular reason to open `Vulnerabilities_list_registries.md` first, and the premise is precisely that they hold a wrong assumption they do not know to check. A vulnerabilities-list entry only reaches someone already looking for known issues.

So the requirement is now recorded as a comment at **both** `proxyHash` comparison sites — `GnosisSafeSameAddressMultisig` and `StakingBase` — stating what the check does *not* prove, why singleton identity is guaranteed upstream instead, and what a caller-supplied-address implementation would have to add. The list entry keeps the full analysis and now points at the comments.

## The de-whitelisting is load-bearing for two entries, and that is now written down

Item 24's "not exploitable" conclusion and item 23 (`deploy` same-address multisig takeover) both rest on the same state: `mapMultisigs` returning `false` for `GnosisSafeSameAddressMultisig` and `PolySafeSameAddressMultisig`. That is a governance-mutable flag, not a code property.

Re-whitelisting either implementation would reopen **both** items at once. Item 24 now says so, and says such a proposal should be treated as a security change gated on the singleton validation landing first — not as a configuration tweak.

## Items 26 and 27 cross-linked

Both describe the same shape: the direct `unbond()` path does not perform cleanup that the alternative path does — the bridger mapping in one case, the operator nonce in the other. Neither referenced the other, so a lifecycle fix to the unbond path could easily address one and leave the other. Each now points at the other.

## Minor

The single `**Severity**: Informational` is now `Informative`, matching the other ten occurrences in the file.
