### PR TITLE
docs: item 23 — record the migration-release case as accepted, not fixed

### DIFF
--- a/docs/Vulnerabilities_list_registries.md
+++ b/docs/Vulnerabilities_list_registries.md
@@ -656,6 +656,17 @@ The fixed implementation is deployed behind the `ServiceManagerProxy` on Ethereu
 supported L2s (see [configuration.json](./configuration.json)), and the binding was back-filled
 across the existing fleet.
 
+**Accepted, not fixed in code: the binding is released on a genuine migration.** When a service
+legitimately moves to a new multisig, `deploy()` clears the previous entry — the service really
+has moved, so keeping the old claim would block the new one. A multisig a service has migrated
+away from is therefore no longer bound to anything, and the 1:1 binding is not what protects it
+from that point on. This is by design and no code change is planned.
+
+The control is operational rather than contract-level: **a service multisig is emptied before it
+is released.** Service operators should treat migration the same way — move the assets out as
+part of the migration, and do not leave value in a multisig the service no longer points at.
+A Safe left funded after its service has moved on is outside what this item's fix covers.
+
 ### 24. Safe proxy-hash validation checks proxy shape, not singleton identity
 
 **Severity**: Informative


### PR DESCRIPTION
Item 23's mitigation section already mentions that the 1:1 `multisig ↔ service` binding *"releases the previous binding on a genuine move"*, but the entry as a whole reads as though the fix closes the class completely. It doesn't, and the remaining case isn't going to be closed in code — so it should be stated rather than left for a reader to infer from one clause.

Adds a short paragraph recording it as an **accepted** condition:

- When a service legitimately migrates to a new multisig, `deploy()` clears the previous entry. That's deliberate — the service really has moved, and keeping the old claim would block the new one.
- The consequence is that a multisig a service has migrated away from is no longer bound to anything, so from that point the binding is not what protects it.
- No code change is planned.

The control is operational rather than contract-level: **a service multisig is emptied before it is released.** The note states that as guidance for service operators, since whoever migrates a service is the party who can act on it — move the assets as part of the migration, and don't leave value in a multisig the service no longer points at.

No change to the fix description, the code sample, or the deployment status above it.
