### PR TITLE
ci: pin the Foundry toolchain to v1.7.1 instead of tracking nightly

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -30,7 +30,14 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          # Pinned to a semver release, not `nightly`. Tracking `nightly` made CI depend on an
+          # unvetted daily build: foundryup resolves a nightly tag whose linux-amd64 asset may
+          # never have been published (HTTP 404), and every job in the repo then fails on an
+          # upstream change with no commit of ours involved. A floating toolchain also means the
+          # runner that validates the contracts can change silently between a review and a merge,
+          # which this repo already avoids for solc.
+          # Bump deliberately, as a reviewable one-line change.
+          version: v1.7.1
 
       # Run linters
       - name: Run ESLint


### PR DESCRIPTION
Every job in this repo is failing right now on an upstream change, with no commit of ours involved:

```
foundryup: downloading foundry_nightly_linux_amd64.tar.gz
Error:
   0: failed to download https://github.com/foundry-rs/foundry/releases/download/
      nightly-e469863b1ac3f2d9d48f9d25d068a14861060cb3/foundry_nightly_linux_amd64.tar.gz:
      HTTP 404 Not Found
```

`main` was green as recently as 2026-08-21 16:50, so nothing in the repo caused this — the nightly asset `foundryup` resolves to is gone.

**`autonolas-tokenomics` hit the identical failure on 2026-08-14** and fixed it by pinning ([`627d05d`](https://github.com/valory-xyz/autonolas-tokenomics/commit/627d05da)). Its CI has been green on `v1.7.1` since, most recently yesterday evening. This applies the same fix here, with the same rationale comment so the next person to touch it knows why it isn't `nightly`.

`v1.7.1` is verified to still publish a `linux_amd64` asset.

Beyond unbreaking the build: a floating toolchain means the runner that validates the contracts can change silently between a review and a merge — the same reason solc is pinned rather than floated. Bumping is now a deliberate, reviewable one-line change.

### Also affected

`autonolas-marketplace` and `autonolas-staking-programmes` still track `nightly` and will fail the same way on their next run. Happy to send the same one-liner to both.
