### PR TITLE
docs: correct item 4's impact — stale agent ids can freeze a service

### DIFF
--- a/docs/Vulnerabilities_list_registries.md
+++ b/docs/Vulnerabilities_list_registries.md
@@ -128,8 +128,7 @@ function update(address serviceOwner, bytes32 configHash, uint32[] memory agentI
 ```
 
 As described earlier, this function allows updating a service in a *pre-registration* state in a
-CRUD way. However, considering that there is no possible direct damage to the protocol
-and to save on transaction gas costs, the function is implemented via an optimistic
+CRUD way. To save on transaction gas costs, the function is implemented via an optimistic
 approach.
 
 Specifically, the service owner might not specify that some of the *agent Ids* of the
@@ -143,6 +142,26 @@ previous setup, declaring that they actually run on current ones (as retrieved v
 We strongly recommend not abusing the *update()* function in order to deploy the service
 to perform any malicious actions by using undeclared *agent Ids*, since this behavior is
 easily spotted off-chain.
+
+**The stale mapping can also freeze a service, which this entry previously did not record.**
+Earlier revisions stated there was "no possible direct damage to the protocol". That
+understates it. Because the omitted ids keep their `(serviceId, agentId)` parameters, a later
+`registerAgents()` can consume the service's remaining slot capacity against those stale ids,
+while `_getAgentInstances()` enumerates only the *current* canonical ids. Deployment then builds
+an owner array containing a zero address, Safe setup reverts, and the service cannot be deployed.
+Terminating it leaves it in `TerminatedBonded` until the operator unbonds, so the service's
+lifecycle is stuck until that happens.
+
+The damage is confined to the service whose owner performed the `update()` — no other service,
+and no protocol-level accounting, is affected — and the escape hatch (operator unbond) always
+exists. But it is a real stuck state reachable through ordinary use of the function, not merely
+a bookkeeping discrepancy, and a service owner should treat leaving stale agent ids in place as
+capable of bricking their own service rather than as a cosmetic inconsistency.
+
+**Mitigation.** When calling `update()`, explicitly zero the `slots` for every agent id being
+removed, so no stale `(serviceId, agentId)` parameters remain to be registered against. On a
+future `ServiceRegistry` revision, clear the parameters of omitted ids inside `update()` rather
+than leaving them for the caller to tidy.
 
 ### 5. `drain` function
 


### PR DESCRIPTION
Item 4 describes the optimistic `update()` design accurately, but its stated impact is wrong. It concludes there is *"no possible direct damage to the protocol"* and closes by recommending against abusing undeclared agent ids because the behaviour is *"easily spotted off-chain"* — framing it as a discipline issue.

The mechanism it documents reaches further. Because omitted ids keep their `(serviceId, agentId)` parameters:

1. a later `registerAgents()` consumes the service's remaining slot capacity against the **stale** mapping;
2. `_getAgentInstances()` enumerates only the **current** canonical ids;
3. deployment therefore builds an owner array containing a zero address and Safe setup reverts;
4. terminating leaves the service in `TerminatedBonded` until the operator unbonds.

That's a stuck service lifecycle reachable through ordinary use of the function — not a bookkeeping discrepancy.

**What changes:** the "no possible direct damage" claim is removed, the freeze is recorded, and a mitigation is added — zero the `slots` for every agent id being removed, and on a future revision clear omitted ids' parameters inside `update()` rather than leaving it to the caller.

**Scope is stated alongside it**, so this reads as a correction rather than an escalation: the damage is confined to the service whose own owner performed the `update()`, no other service or protocol-level accounting is affected, and operator unbond is always available as an escape. The severity rating is unchanged.
