### PR TITLE
feat(mode): deploy ComplementaryServiceMetadata, add a checker, and fix what it found

### DIFF
--- a/abis/0.8.30-no-optimizer/ComplementaryServiceMetadata.json
+++ b/abis/0.8.30-no-optimizer/ComplementaryServiceMetadata.json
@@ -1,0 +1,471 @@
+{
+  "abi": [
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_serviceRegistry",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "nonpayable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "ReentrancyGuard",
+      "type": "error"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "UnauthorizedAccount",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroAddress",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "serviceId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "hash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "ComplementaryMetadataUpdated",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "CID_PREFIX",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "VERSION",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "baseURI",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "serviceId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes32",
+          "name": "hash",
+          "type": "bytes32"
+        }
+      ],
+      "name": "changeHash",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "serviceId",
+          "type": "uint256"
+        }
+      ],
+      "name": "isAbleChangeHash",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "mapServiceHashes",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "serviceRegistry",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "serviceId",
+          "type": "uint256"
+        }
+      ],
+      "name": "tokenURI",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "bytecode": "0x60a060405260018055348015610013575f5ffd5b506040516115d33803806115d3833981810160405281019061003591906101bf565b5f73ffffffffffffffffffffffffffffffffffffffff168173ffffffffffffffffffffffffffffffffffffffff160361009a576040517fd92e233d00000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b8073ffffffffffffffffffffffffffffffffffffffff1660808173ffffffffffffffffffffffffffffffffffffffff168152505060805173ffffffffffffffffffffffffffffffffffffffff16636c0360eb6040518163ffffffff1660e01b81526004015f60405180830381865afa158015610118573d5f5f3e3d5ffd5b505050506040513d5f823e3d601f19601f820116820180604052508101906101409190610326565b5f908161014d919061057d565b505061064c565b5f604051905090565b5f5ffd5b5f5ffd5b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f61018e82610165565b9050919050565b61019e81610184565b81146101a8575f5ffd5b50565b5f815190506101b981610195565b92915050565b5f602082840312156101d4576101d361015d565b5b5f6101e1848285016101ab565b91505092915050565b5f5ffd5b5f5ffd5b5f601f19601f8301169050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52604160045260245ffd5b610238826101f2565b810181811067ffffffffffffffff8211171561025757610256610202565b5b80604052505050565b5f610269610154565b9050610275828261022f565b919050565b5f67ffffffffffffffff82111561029457610293610202565b5b61029d826101f2565b9050602081019050919050565b8281835e5f83830152505050565b5f6102ca6102c58461027a565b610260565b9050828152602081018484840111156102e6576102e56101ee565b5b6102f18482856102aa565b509392505050565b5f82601f83011261030d5761030c6101ea565b5b815161031d8482602086016102b8565b91505092915050565b5f6020828403121561033b5761033a61015d565b5b5f82015167ffffffffffffffff81111561035857610357610161565b5b610364848285016102f9565b91505092915050565b5f81519050919050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f60028204905060018216806103bb57607f821691505b6020821081036103ce576103cd610377565b5b50919050565b5f819050815f5260205f209050919050565b5f6020601f8301049050919050565b5f82821b905092915050565b5f600883026104307fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff826103f5565b61043a86836103f5565b95508019841693508086168417925050509392505050565b5f819050919050565b5f819050919050565b5f61047e61047961047484610452565b61045b565b610452565b9050919050565b5f819050919050565b61049783610464565b6104ab6104a382610485565b848454610401565b825550505050565b5f5f905090565b6104c26104b3565b6104cd81848461048e565b505050565b5b818110156104f0576104e55f826104ba565b6001810190506104d3565b5050565b601f82111561053557610506816103d4565b61050f846103e6565b8101602085101561051e578190505b61053261052a856103e6565b8301826104d2565b50505b505050565b5f82821c905092915050565b5f6105555f198460080261053a565b1980831691505092915050565b5f61056d8383610546565b9150826002028217905092915050565b6105868261036d565b67ffffffffffffffff81111561059f5761059e610202565b5b6105a982546103a4565b6105b48282856104f4565b5f60209050601f8311600181146105e5575f84156105d3578287015190505b6105dd8582610562565b865550610644565b601f1984166105f3866103d4565b5f5b8281101561061a578489015182556001820191506020850194506020810190506105f5565b868310156106375784890151610633601f891682610546565b8355505b6001600288020188555050505b505050505050565b608051610f616106725f395f818161036a0152818161047a01526105ef0152610f615ff3fe608060405234801561000f575f5ffd5b5060043610610086575f3560e01c8063b764348a11610059578063b764348a14610112578063c87b56dd14610142578063cbcf252a14610172578063ffa1ad741461019057610086565b806344a885ff1461008a5780634a086201146100a65780636c0360eb146100d65780637c5e63e0146100f4575b5f5ffd5b6100a4600480360381019061009f9190610906565b6101ae565b005b6100c060048036038101906100bb9190610944565b61028c565b6040516100cd919061097e565b60405180910390f35b6100de6102a1565b6040516100eb9190610a07565b60405180910390f35b6100fc61032c565b6040516101099190610a07565b60405180910390f35b61012c60048036038101906101279190610a81565b610365565b6040516101399190610ad9565b60405180910390f35b61015c60048036038101906101579190610944565b61055f565b6040516101699190610a07565b60405180910390f35b61017a6105ed565b6040516101879190610b01565b60405180910390f35b610198610611565b6040516101a59190610a07565b60405180910390f35b6002600154036101ea576040517f8beb9d1600000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60026001819055506101fc3383610365565b61023d57336040517f32b2baa30000000000000000000000000000000000000000000000000000000081526004016102349190610b01565b60405180910390fd5b8060025f8481526020019081526020015f208190555080827f87f9ed4fb4b8e6e4fae8db70df4b9445f5afb00ed253374f9d87cad37813068d60405160405180910390a3600180819055505050565b6002602052805f5260405f205f915090505481565b5f80546102ad90610b47565b80601f01602080910402602001604051908101604052809291908181526020018280546102d990610b47565b80156103245780601f106102fb57610100808354040283529160200191610324565b820191905f5260205f20905b81548152906001019060200180831161030757829003601f168201915b505050505081565b6040518060400160405280600981526020017f663031373031323230000000000000000000000000000000000000000000000081525081565b5f5f5f7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16634236aff8856040518263ffffffff1660e01b81526004016103c19190610b86565b60e060405180830381865afa1580156103dc573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906104009190610c64565b9650505050509250506004600581111561041d5761041c610d01565b5b8160058111156104305761042f610d01565b5b03610477578173ffffffffffffffffffffffffffffffffffffffff168573ffffffffffffffffffffffffffffffffffffffff1614610472575f92505050610559565b610552565b5f7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16636352211e866040518263ffffffff1660e01b81526004016104d19190610b86565b602060405180830381865afa1580156104ec573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906105109190610d2e565b90508073ffffffffffffffffffffffffffffffffffffffff168673ffffffffffffffffffffffffffffffffffffffff1614610550575f9350505050610559565b505b6001925050505b92915050565b60605f60025f8481526020019081526020015f205490505f6040518060400160405280600981526020017f66303137303132323000000000000000000000000000000000000000000000008152506105b68361064a565b6105c3608085901b61064a565b6040516020016105d69493929190610e45565b604051602081830303815290604052915050919050565b7f000000000000000000000000000000000000000000000000000000000000000081565b6040518060400160405280600581526020017f302e312e3000000000000000000000000000000000000000000000000000000081525081565b5f604077ffffffffffffffff000000000000000000000000000000005f1b836fffffffffffffffffffffffffffffffff191616901c7fffffffffffffffff0000000000000000000000000000000000000000000000005f1b836fffffffffffffffffffffffffffffffff19161617905060207bffffffff000000000000000000000000ffffffff00000000000000005f1b8216901c7fffffffff000000000000000000000000ffffffff0000000000000000000000005f1b821617905060107dffff000000000000ffff000000000000ffff000000000000ffff000000005f1b8216901c7fffff000000000000ffff000000000000ffff000000000000ffff0000000000005f1b821617905060087eff000000ff000000ff000000ff000000ff000000ff000000ff000000ff00005f1b8216901c7fff000000ff000000ff000000ff000000ff000000ff000000ff000000ff0000005f1b821617905060087f0f000f000f000f000f000f000f000f000f000f000f000f000f000f000f000f005f1b8216901c60047ff000f000f000f000f000f000f000f000f000f000f000f000f000f000f000f0005f1b8316901c17905060277f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f60047f0606060606060606060606060606060606060606060606060606060606060606845f1c61084e9190610eb7565b901c1661085b9190610eea565b815f1c7f30303030303030303030303030303030303030303030303030303030303030306108899190610eb7565b6108939190610eb7565b5f1b9050919050565b5f5ffd5b5f819050919050565b6108b2816108a0565b81146108bc575f5ffd5b50565b5f813590506108cd816108a9565b92915050565b5f819050919050565b6108e5816108d3565b81146108ef575f5ffd5b50565b5f81359050610900816108dc565b92915050565b5f5f6040838503121561091c5761091b61089c565b5b5f610929858286016108bf565b925050602061093a858286016108f2565b9150509250929050565b5f602082840312156109595761095861089c565b5b5f610966848285016108bf565b91505092915050565b610978816108d3565b82525050565b5f6020820190506109915f83018461096f565b92915050565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f6109d982610997565b6109e381856109a1565b93506109f38185602086016109b1565b6109fc816109bf565b840191505092915050565b5f6020820190508181035f830152610a1f81846109cf565b905092915050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f610a5082610a27565b9050919050565b610a6081610a46565b8114610a6a575f5ffd5b50565b5f81359050610a7b81610a57565b92915050565b5f5f60408385031215610a9757610a9661089c565b5b5f610aa485828601610a6d565b9250506020610ab5858286016108bf565b9150509250929050565b5f8115159050919050565b610ad381610abf565b82525050565b5f602082019050610aec5f830184610aca565b92915050565b610afb81610a46565b82525050565b5f602082019050610b145f830184610af2565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f6002820490506001821680610b5e57607f821691505b602082108103610b7157610b70610b1a565b5b50919050565b610b80816108a0565b82525050565b5f602082019050610b995f830184610b77565b92915050565b5f6bffffffffffffffffffffffff82169050919050565b610bbf81610b9f565b8114610bc9575f5ffd5b50565b5f81519050610bda81610bb6565b92915050565b5f81519050610bee81610a57565b92915050565b5f81519050610c02816108dc565b92915050565b5f63ffffffff82169050919050565b610c2081610c08565b8114610c2a575f5ffd5b50565b5f81519050610c3b81610c17565b92915050565b60068110610c4d575f5ffd5b50565b5f81519050610c5e81610c41565b92915050565b5f5f5f5f5f5f5f60e0888a031215610c7f57610c7e61089c565b5b5f610c8c8a828b01610bcc565b9750506020610c9d8a828b01610be0565b9650506040610cae8a828b01610bf4565b9550506060610cbf8a828b01610c2d565b9450506080610cd08a828b01610c2d565b93505060a0610ce18a828b01610c2d565b92505060c0610cf28a828b01610c50565b91505092959891949750929550565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b5f60208284031215610d4357610d4261089c565b5b5f610d5084828501610be0565b91505092915050565b5f81905092915050565b5f819050815f5260205f209050919050565b5f8154610d8181610b47565b610d8b8186610d59565b9450600182165f8114610da55760018114610dba57610dec565b60ff1983168652811515820286019350610dec565b610dc385610d63565b5f5b83811015610de457815481890152600182019150602081019050610dc5565b838801955050505b50505092915050565b5f610dff82610997565b610e098185610d59565b9350610e198185602086016109b1565b80840191505092915050565b5f819050919050565b610e3f610e3a826108d3565b610e25565b82525050565b5f610e508287610d75565b9150610e5c8286610df5565b9150610e688285610e2e565b602082019150610e788284610e2e565b60208201915081905095945050505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f610ec1826108a0565b9150610ecc836108a0565b9250828201905080821115610ee457610ee3610e8a565b5b92915050565b5f610ef4826108a0565b9150610eff836108a0565b9250828202610f0d816108a0565b91508282048414831517610f2457610f23610e8a565b5b509291505056fea264697066735822122022673a3c68b37ca1e93455be3a5678dbc8e74b858e592835105e275856d8157764736f6c634300081e0033",
+  "deployedBytecode": "0x608060405234801561000f575f5ffd5b5060043610610086575f3560e01c8063b764348a11610059578063b764348a14610112578063c87b56dd14610142578063cbcf252a14610172578063ffa1ad741461019057610086565b806344a885ff1461008a5780634a086201146100a65780636c0360eb146100d65780637c5e63e0146100f4575b5f5ffd5b6100a4600480360381019061009f9190610906565b6101ae565b005b6100c060048036038101906100bb9190610944565b61028c565b6040516100cd919061097e565b60405180910390f35b6100de6102a1565b6040516100eb9190610a07565b60405180910390f35b6100fc61032c565b6040516101099190610a07565b60405180910390f35b61012c60048036038101906101279190610a81565b610365565b6040516101399190610ad9565b60405180910390f35b61015c60048036038101906101579190610944565b61055f565b6040516101699190610a07565b60405180910390f35b61017a6105ed565b6040516101879190610b01565b60405180910390f35b610198610611565b6040516101a59190610a07565b60405180910390f35b6002600154036101ea576040517f8beb9d1600000000000000000000000000000000000000000000000000000000815260040160405180910390fd5b60026001819055506101fc3383610365565b61023d57336040517f32b2baa30000000000000000000000000000000000000000000000000000000081526004016102349190610b01565b60405180910390fd5b8060025f8481526020019081526020015f208190555080827f87f9ed4fb4b8e6e4fae8db70df4b9445f5afb00ed253374f9d87cad37813068d60405160405180910390a3600180819055505050565b6002602052805f5260405f205f915090505481565b5f80546102ad90610b47565b80601f01602080910402602001604051908101604052809291908181526020018280546102d990610b47565b80156103245780601f106102fb57610100808354040283529160200191610324565b820191905f5260205f20905b81548152906001019060200180831161030757829003601f168201915b505050505081565b6040518060400160405280600981526020017f663031373031323230000000000000000000000000000000000000000000000081525081565b5f5f5f7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16634236aff8856040518263ffffffff1660e01b81526004016103c19190610b86565b60e060405180830381865afa1580156103dc573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906104009190610c64565b9650505050509250506004600581111561041d5761041c610d01565b5b8160058111156104305761042f610d01565b5b03610477578173ffffffffffffffffffffffffffffffffffffffff168573ffffffffffffffffffffffffffffffffffffffff1614610472575f92505050610559565b610552565b5f7f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16636352211e866040518263ffffffff1660e01b81526004016104d19190610b86565b602060405180830381865afa1580156104ec573d5f5f3e3d5ffd5b505050506040513d601f19601f820116820180604052508101906105109190610d2e565b90508073ffffffffffffffffffffffffffffffffffffffff168673ffffffffffffffffffffffffffffffffffffffff1614610550575f9350505050610559565b505b6001925050505b92915050565b60605f60025f8481526020019081526020015f205490505f6040518060400160405280600981526020017f66303137303132323000000000000000000000000000000000000000000000008152506105b68361064a565b6105c3608085901b61064a565b6040516020016105d69493929190610e45565b604051602081830303815290604052915050919050565b7f000000000000000000000000000000000000000000000000000000000000000081565b6040518060400160405280600581526020017f302e312e3000000000000000000000000000000000000000000000000000000081525081565b5f604077ffffffffffffffff000000000000000000000000000000005f1b836fffffffffffffffffffffffffffffffff191616901c7fffffffffffffffff0000000000000000000000000000000000000000000000005f1b836fffffffffffffffffffffffffffffffff19161617905060207bffffffff000000000000000000000000ffffffff00000000000000005f1b8216901c7fffffffff000000000000000000000000ffffffff0000000000000000000000005f1b821617905060107dffff000000000000ffff000000000000ffff000000000000ffff000000005f1b8216901c7fffff000000000000ffff000000000000ffff000000000000ffff0000000000005f1b821617905060087eff000000ff000000ff000000ff000000ff000000ff000000ff000000ff00005f1b8216901c7fff000000ff000000ff000000ff000000ff000000ff000000ff000000ff0000005f1b821617905060087f0f000f000f000f000f000f000f000f000f000f000f000f000f000f000f000f005f1b8216901c60047ff000f000f000f000f000f000f000f000f000f000f000f000f000f000f000f0005f1b8316901c17905060277f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f0f60047f0606060606060606060606060606060606060606060606060606060606060606845f1c61084e9190610eb7565b901c1661085b9190610eea565b815f1c7f30303030303030303030303030303030303030303030303030303030303030306108899190610eb7565b6108939190610eb7565b5f1b9050919050565b5f5ffd5b5f819050919050565b6108b2816108a0565b81146108bc575f5ffd5b50565b5f813590506108cd816108a9565b92915050565b5f819050919050565b6108e5816108d3565b81146108ef575f5ffd5b50565b5f81359050610900816108dc565b92915050565b5f5f6040838503121561091c5761091b61089c565b5b5f610929858286016108bf565b925050602061093a858286016108f2565b9150509250929050565b5f602082840312156109595761095861089c565b5b5f610966848285016108bf565b91505092915050565b610978816108d3565b82525050565b5f6020820190506109915f83018461096f565b92915050565b5f81519050919050565b5f82825260208201905092915050565b8281835e5f83830152505050565b5f601f19601f8301169050919050565b5f6109d982610997565b6109e381856109a1565b93506109f38185602086016109b1565b6109fc816109bf565b840191505092915050565b5f6020820190508181035f830152610a1f81846109cf565b905092915050565b5f73ffffffffffffffffffffffffffffffffffffffff82169050919050565b5f610a5082610a27565b9050919050565b610a6081610a46565b8114610a6a575f5ffd5b50565b5f81359050610a7b81610a57565b92915050565b5f5f60408385031215610a9757610a9661089c565b5b5f610aa485828601610a6d565b9250506020610ab5858286016108bf565b9150509250929050565b5f8115159050919050565b610ad381610abf565b82525050565b5f602082019050610aec5f830184610aca565b92915050565b610afb81610a46565b82525050565b5f602082019050610b145f830184610af2565b92915050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602260045260245ffd5b5f6002820490506001821680610b5e57607f821691505b602082108103610b7157610b70610b1a565b5b50919050565b610b80816108a0565b82525050565b5f602082019050610b995f830184610b77565b92915050565b5f6bffffffffffffffffffffffff82169050919050565b610bbf81610b9f565b8114610bc9575f5ffd5b50565b5f81519050610bda81610bb6565b92915050565b5f81519050610bee81610a57565b92915050565b5f81519050610c02816108dc565b92915050565b5f63ffffffff82169050919050565b610c2081610c08565b8114610c2a575f5ffd5b50565b5f81519050610c3b81610c17565b92915050565b60068110610c4d575f5ffd5b50565b5f81519050610c5e81610c41565b92915050565b5f5f5f5f5f5f5f60e0888a031215610c7f57610c7e61089c565b5b5f610c8c8a828b01610bcc565b9750506020610c9d8a828b01610be0565b9650506040610cae8a828b01610bf4565b9550506060610cbf8a828b01610c2d565b9450506080610cd08a828b01610c2d565b93505060a0610ce18a828b01610c2d565b92505060c0610cf28a828b01610c50565b91505092959891949750929550565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52602160045260245ffd5b5f60208284031215610d4357610d4261089c565b5b5f610d5084828501610be0565b91505092915050565b5f81905092915050565b5f819050815f5260205f209050919050565b5f8154610d8181610b47565b610d8b8186610d59565b9450600182165f8114610da55760018114610dba57610dec565b60ff1983168652811515820286019350610dec565b610dc385610d63565b5f5b83811015610de457815481890152600182019150602081019050610dc5565b838801955050505b50505092915050565b5f610dff82610997565b610e098185610d59565b9350610e198185602086016109b1565b80840191505092915050565b5f819050919050565b610e3f610e3a826108d3565b610e25565b82525050565b5f610e508287610d75565b9150610e5c8286610df5565b9150610e688285610e2e565b602082019150610e788284610e2e565b60208201915081905095945050505050565b7f4e487b71000000000000000000000000000000000000000000000000000000005f52601160045260245ffd5b5f610ec1826108a0565b9150610ecc836108a0565b9250828201905080821115610ee457610ee3610e8a565b5b92915050565b5f610ef4826108a0565b9150610eff836108a0565b9250828202610f0d816108a0565b91508282048414831517610f2457610f23610e8a565b5b509291505056fea264697066735822122022673a3c68b37ca1e93455be3a5678dbc8e74b858e592835105e275856d8157764736f6c634300081e0033",
+  "methodIdentifiers": {
+    "CID_PREFIX()": "7c5e63e0",
+    "VERSION()": "ffa1ad74",
+    "baseURI()": "6c0360eb",
+    "changeHash(uint256,bytes32)": "44a885ff",
+    "isAbleChangeHash(address,uint256)": "b764348a",
+    "mapServiceHashes(uint256)": "4a086201",
+    "serviceRegistry()": "cbcf252a",
+    "tokenURI(uint256)": "c87b56dd"
+  },
+  "rawMetadata": "{\"compiler\":{\"version\":\"0.8.30+commit.73712a01\"},\"language\":\"Solidity\",\"output\":{\"abi\":[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_serviceRegistry\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[],\"name\":\"ReentrancyGuard\",\"type\":\"error\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"}],\"name\":\"UnauthorizedAccount\",\"type\":\"error\"},{\"inputs\":[],\"name\":\"ZeroAddress\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"serviceId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"bytes32\",\"name\":\"hash\",\"type\":\"bytes32\"}],\"name\":\"ComplementaryMetadataUpdated\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"CID_PREFIX\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"VERSION\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"baseURI\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"serviceId\",\"type\":\"uint256\"},{\"internalType\":\"bytes32\",\"name\":\"hash\",\"type\":\"bytes32\"}],\"name\":\"changeHash\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"account\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"serviceId\",\"type\":\"uint256\"}],\"name\":\"isAbleChangeHash\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"mapServiceHashes\",\"outputs\":[{\"internalType\":\"bytes32\",\"name\":\"\",\"type\":\"bytes32\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"serviceRegistry\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"serviceId\",\"type\":\"uint256\"}],\"name\":\"tokenURI\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"}],\"devdoc\":{\"author\":\"Aleksandr Kuperman - <aleksandr.kuperman@valory.xyz>Andrey Lebedev - <andrey.lebedev@valory.xyz>Mariapia Moscatiello - <mariapia.moscatiello@valory.xyz>\",\"errors\":{\"ReentrancyGuard()\":[{\"details\":\"Caught reentrancy violation.\"}],\"UnauthorizedAccount(address)\":[{\"details\":\"Account is unauthorized.\",\"params\":{\"account\":\"Account address.\"}}],\"ZeroAddress()\":[{\"details\":\"Provided zero address.\"}]},\"kind\":\"dev\",\"methods\":{\"changeHash(uint256,bytes32)\":{\"details\":\"Changes metadata hash.\",\"params\":{\"hash\":\"Updated metadata hash.\",\"serviceId\":\"Service id.\"}},\"constructor\":{\"details\":\"ComplementaryServiceMetadata constructor.\",\"params\":{\"_serviceRegistry\":\"Service Registry address.\"}},\"isAbleChangeHash(address,uint256)\":{\"details\":\"Checks if account is able to change service metadata hash.\",\"params\":{\"account\":\"Account address.\",\"serviceId\":\"Service id.\"},\"returns\":{\"_0\":\"True if account has access, false otherwise.\"}},\"tokenURI(uint256)\":{\"details\":\"Returns complementary service token URI.\",\"params\":{\"serviceId\":\"Service Id.\"},\"returns\":{\"_0\":\"Complementary service token URI string.\"}}},\"title\":\"ComplementaryServiceMetadata - Complementary Service Metadata contract to manage complementary service hashes\",\"version\":1},\"userdoc\":{\"kind\":\"user\",\"methods\":{\"tokenURI(uint256)\":{\"notice\":\"Expected multicodec: dag-pb; hashing function: sha2-256, with base16 encoding and leading CID_PREFIX removed.\"}},\"version\":1}},\"settings\":{\"compilationTarget\":{\"contracts/utils/ComplementaryServiceMetadata.sol\":\"ComplementaryServiceMetadata\"},\"evmVersion\":\"prague\",\"libraries\":{},\"metadata\":{\"bytecodeHash\":\"ipfs\"},\"optimizer\":{\"enabled\":true,\"runs\":750},\"remappings\":[\":@gnosis.pm/=node_modules/@gnosis.pm/\",\":ds-test/=lib/solmate/lib/ds-test/src/\",\":forge-std/=lib/forge-std/src/\",\":solmate/=lib/solmate/src/\"]},\"sources\":{\"contracts/utils/ComplementaryServiceMetadata.sol\":{\"keccak256\":\"0x343b479075aa9bd403249e7031ab105dc31d217f3b824a2dd214989f15a18caa\",\"license\":\"MIT\",\"urls\":[\"bzz-raw://7276a1a920c92412069495eda8c3098f7082ce8749dcee142423b70e416c9904\",\"dweb:/ipfs/QmYaJtKjoTUyfr2bFDEwaPKcxg9bTwsNHKu7YRmnPtDPms\"]}},\"version\":1}",
+  "metadata": {
+    "compiler": {
+      "version": "0.8.30+commit.73712a01"
+    },
+    "language": "Solidity",
+    "output": {
+      "abi": [
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "_serviceRegistry",
+              "type": "address"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "constructor"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ReentrancyGuard"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            }
+          ],
+          "type": "error",
+          "name": "UnauthorizedAccount"
+        },
+        {
+          "inputs": [],
+          "type": "error",
+          "name": "ZeroAddress"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "serviceId",
+              "type": "uint256",
+              "indexed": true
+            },
+            {
+              "internalType": "bytes32",
+              "name": "hash",
+              "type": "bytes32",
+              "indexed": true
+            }
+          ],
+          "type": "event",
+          "name": "ComplementaryMetadataUpdated",
+          "anonymous": false
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "CID_PREFIX",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "VERSION",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "baseURI",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "serviceId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bytes32",
+              "name": "hash",
+              "type": "bytes32"
+            }
+          ],
+          "stateMutability": "nonpayable",
+          "type": "function",
+          "name": "changeHash"
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "serviceId",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "isAbleChangeHash",
+          "outputs": [
+            {
+              "internalType": "bool",
+              "name": "",
+              "type": "bool"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "mapServiceHashes",
+          "outputs": [
+            {
+              "internalType": "bytes32",
+              "name": "",
+              "type": "bytes32"
+            }
+          ]
+        },
+        {
+          "inputs": [],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "serviceRegistry",
+          "outputs": [
+            {
+              "internalType": "address",
+              "name": "",
+              "type": "address"
+            }
+          ]
+        },
+        {
+          "inputs": [
+            {
+              "internalType": "uint256",
+              "name": "serviceId",
+              "type": "uint256"
+            }
+          ],
+          "stateMutability": "view",
+          "type": "function",
+          "name": "tokenURI",
+          "outputs": [
+            {
+              "internalType": "string",
+              "name": "",
+              "type": "string"
+            }
+          ]
+        }
+      ],
+      "devdoc": {
+        "kind": "dev",
+        "methods": {
+          "changeHash(uint256,bytes32)": {
+            "details": "Changes metadata hash.",
+            "params": {
+              "hash": "Updated metadata hash.",
+              "serviceId": "Service id."
+            }
+          },
+          "constructor": {
+            "details": "ComplementaryServiceMetadata constructor.",
+            "params": {
+              "_serviceRegistry": "Service Registry address."
+            }
+          },
+          "isAbleChangeHash(address,uint256)": {
+            "details": "Checks if account is able to change service metadata hash.",
+            "params": {
+              "account": "Account address.",
+              "serviceId": "Service id."
+            },
+            "returns": {
+              "_0": "True if account has access, false otherwise."
+            }
+          },
+          "tokenURI(uint256)": {
+            "details": "Returns complementary service token URI.",
+            "params": {
+              "serviceId": "Service Id."
+            },
+            "returns": {
+              "_0": "Complementary service token URI string."
+            }
+          }
+        },
+        "version": 1
+      },
+      "userdoc": {
+        "kind": "user",
+        "methods": {
+          "tokenURI(uint256)": {
+            "notice": "Expected multicodec: dag-pb; hashing function: sha2-256, with base16 encoding and leading CID_PREFIX removed."
+          }
+        },
+        "version": 1
+      }
+    },
+    "settings": {
+      "remappings": [
+        "@gnosis.pm/=node_modules/@gnosis.pm/",
+        "ds-test/=lib/solmate/lib/ds-test/src/",
+        "forge-std/=lib/forge-std/src/",
+        "solmate/=lib/solmate/src/"
+      ],
+      "optimizer": {
+        "enabled": true,
+        "runs": 750
+      },
+      "metadata": {
+        "bytecodeHash": "ipfs"
+      },
+      "compilationTarget": {
+        "contracts/utils/ComplementaryServiceMetadata.sol": "ComplementaryServiceMetadata"
+      },
+      "evmVersion": "prague",
+      "libraries": {}
+    },
+    "sources": {
+      "contracts/utils/ComplementaryServiceMetadata.sol": {
+        "keccak256": "0x343b479075aa9bd403249e7031ab105dc31d217f3b824a2dd214989f15a18caa",
+        "urls": [
+          "bzz-raw://7276a1a920c92412069495eda8c3098f7082ce8749dcee142423b70e416c9904",
+          "dweb:/ipfs/QmYaJtKjoTUyfr2bFDEwaPKcxg9bTwsNHKu7YRmnPtDPms"
+        ],
+        "license": "MIT"
+      }
+    },
+    "version": 1
+  },
+  "id": 41
+}

--- a/abis/README.md
+++ b/abis/README.md
@@ -1,2 +1,9 @@
 # Autonolas registries ABIs
 These ABIs were obtained with 750 optimization passes.
+
+`abis/0.8.30-no-optimizer/` holds artifacts for deployments made before `foundry.toml` carried
+`optimizer`/`optimizer_runs`. The gnosis and base `ComplementaryServiceMetadata` contracts were
+deployed on 2025-06-18, and the very commit that recorded that deployment is the one that added the
+optimizer settings — so both are unoptimized builds at 3937 B against the 2517 B optimized artifact.
+Same source, same solc, same `evm_version`; only the optimizer differs. If either is redeployed,
+delete the artifact and repoint the entry back at `abis/0.8.30/`.

--- a/docs/configuration.json
+++ b/docs/configuration.json
@@ -262,7 +262,7 @@
       },
       {
         "name": "ComplementaryServiceMetadata",
-        "artifact": "abis/0.8.30/ComplementaryServiceMetadata.json",
+        "artifact": "abis/0.8.30-no-optimizer/ComplementaryServiceMetadata.json",
         "address": "0x0598081D48FB80B0A7E52FAD2905AE9beCd6fC69"
       },
       {
@@ -515,7 +515,7 @@
       },
       {
         "name": "ComplementaryServiceMetadata",
-        "artifact": "abis/0.8.30/ComplementaryServiceMetadata.json",
+        "artifact": "abis/0.8.30-no-optimizer/ComplementaryServiceMetadata.json",
         "address": "0x28C1edC7CEd549F7f80B732fDC19f0370160707d"
       },
       {

--- a/docs/configuration.json
+++ b/docs/configuration.json
@@ -679,6 +679,11 @@
         "name": "SafeMultisigWithRecoveryModule",
         "artifact": "abis/0.8.30/SafeMultisigWithRecoveryModule.json",
         "address": "0x7Fd1F4b764fA41d19fe3f63C85d12bf64d2bbf68"
+      },
+      {
+        "name": "ComplementaryServiceMetadata",
+        "artifact": "abis/0.8.30/ComplementaryServiceMetadata.json",
+        "address": "0x24F792D51b398928459Dfbb4181bDb4D5d2CD472"
       }
     ]
   }

--- a/scripts/audit_chains/audit_contracts_setup.js
+++ b/scripts/audit_chains/audit_contracts_setup.js
@@ -453,6 +453,27 @@ async function checkServiceRegistryTokenUtility(chainId, provider, globalsInstan
 
 // Check operator whitelist: chain Id, provider, parsed globals, configuration contracts, contract name
 // At the moment the check is applicable to L1 only
+// Check ComplementaryServiceMetadata: chain Id, provider, parsed globals, configuration contracts, contract name
+async function checkComplementaryServiceMetadata(chainId, provider, globalsInstance, configContracts, contractName, log) {
+    // Get the contract instance - not deployed on every chain
+    const complementaryServiceMetadata = await findContractInstance(provider, configContracts, contractName);
+    if (typeof complementaryServiceMetadata === "undefined") {
+        warnNotConfigured(log, contractName);
+        return;
+    }
+
+    // Check the bytecode
+    await checkBytecode(provider, configContracts, contractName, log);
+
+    log += ", address: " + complementaryServiceMetadata.address;
+
+    // Check the service registry it was constructed against. This is the contract's only wiring - it
+    // is not Ownable, and permissions derive from serviceRegistry.ownerOf(), so a wrong registry here
+    // is the whole failure mode rather than one of several.
+    const serviceRegistry = await complementaryServiceMetadata.serviceRegistry();
+    customExpect(serviceRegistry, globalsInstance["serviceRegistryAddress"], log + ", function: serviceRegistry()");
+}
+
 // Check HashCheckpoint: chain Id, provider, parsed globals, configuration contracts, contract name
 async function checkHashCheckpoint(chainId, provider, globalsInstance, configContracts, contractName, log) {
     // Get the contract instance - HashCheckpoint is only deployed on some chains
@@ -777,6 +798,9 @@ async function main() {
 
             log = initLog + ", contract: " + "HashCheckpoint";
             await checkHashCheckpoint(configs[i]["chainId"], providers[i], globals[i], configs[i]["contracts"], "HashCheckpoint", log);
+
+            log = initLog + ", contract: " + "ComplementaryServiceMetadata";
+            await checkComplementaryServiceMetadata(configs[i]["chainId"], providers[i], globals[i], configs[i]["contracts"], "ComplementaryServiceMetadata", log);
 
             log = initLog + ", contract: " + "GnosisSafeMultisig";
             await checkGnosisSafeMultisig(configs[i]["chainId"], providers[i], globals[i], configs[i]["contracts"], "GnosisSafeMultisig", log);

--- a/scripts/deployment/l2/globals_mode_mainnet.json
+++ b/scripts/deployment/l2/globals_mode_mainnet.json
@@ -37,5 +37,6 @@
   "recoveryModuleAddress": "0x1d79e0a600B61FAC1B8F40c27347e48962Ed2f23",
   "safeMultisigWithRecoveryModuleAddress": "0x7Fd1F4b764fA41d19fe3f63C85d12bf64d2bbf68",
   "serviceManagerProxyAddress": "0xcDdD9D9ABaB36fFa882530D69c73FeE5D4001C2d",
-  "agent8004BaseURI": "https://marketplace.olas.network/erc8004/mode-mainnet/ai-agents/"
+  "agent8004BaseURI": "https://marketplace.olas.network/erc8004/mode-mainnet/ai-agents/",
+  "complementaryServiceMetadataAddress": "0x24F792D51b398928459Dfbb4181bDb4D5d2CD472"
 }


### PR DESCRIPTION
Deploys the one contract mode was missing that is not blocked on 8004, closes the coverage gap that let it go unverified everywhere, and fixes what that check found.

## Deployment

**`0x24F792D51b398928459Dfbb4181bDb4D5d2CD472`** on mode, constructed against mode's `ServiceRegistryL2` `0x3C1fF68f`.

Deployed code is **2,517 B — an exact match to `abis/0.8.30/ComplementaryServiceMetadata.json`**, so no new artifact was needed; hardhat and foundry are configured identically here (0.8.30, 750 runs, `prague`). Verified on Etherscan and Blockscout. The contract is **not `Ownable`** — permissions derive from `serviceRegistry.ownerOf()` — so no ownership transfer follows.

## The checker is new

`ComplementaryServiceMetadata` was in `docs/configuration.json` on **seven chains and verified in no way at all** — the same gap `HashCheckpoint` had before [#316](https://github.com/valory-xyz/autonolas-registries/pull/316). It now gets the Tier-1 bytecode check plus its `serviceRegistry()` wiring, which is the contract's only wiring and therefore its whole failure mode. Absence warns rather than passing silently.

## What it found, and the fix

```
gnosis 0x0598081D  on-chain 3937 B  vs artifact 2517 B
base   0x28C1edC7  on-chain 3937 B  vs artifact 2517 B
```

Both were deployed on 2025-06-18, and **`d935142` — the very commit that records that deployment — is the one that added `optimizer`/`optimizer_runs` to `foundry.toml`**. So both are unoptimized builds.

Compiling the current source at solc 0.8.30 with the optimizer **off** reproduces **3,937 B exactly**; with it on at 750 runs it gives the 2,517 B already committed. Same source, same solc, same `evm_version` — only the optimizer differs.

`abis/0.8.30-no-optimizer/ComplementaryServiceMetadata.json` records what those two run, and their entries point at it. **Both now pass Tier-1**; the metadata trailer still differs, which is the Tier-2 warning and correct.

This is the identical situation to the gnosis and base `SubscriptionProvider`s in `autonolas-marketplace` — same two chains, same month, same missing `foundry.toml` settings — and it is recorded the same way, including the note to delete the artifact and repoint if either is redeployed.

## Result

Mode's deployment passes, both previously-invisible failures are resolved, and `serviceRegistry()` is correct on every chain.
