### PR TITLE
docs: fix the entry 12 table-of-contents anchor

### DIFF
--- a/docs/Vulnerabilities_list_registries.md
+++ b/docs/Vulnerabilities_list_registries.md
@@ -15,7 +15,7 @@
     - [9. unstake function](#9-unstake-function)
     - [10. checkpoint function: O(n) complexity due to gas overflow](#10-checkpoint-function-on-complexity-and-dos-due-to-gas-overflow)
     - [11. deploy function](#11-deploy-function)
-    - [12. create function](#12-create-function-1)
+    - [12. create function](#12-create-function)
     - [13. execTransaction return value in RecoveryModule and other multisig creating contracts](#13-exectransaction-return-value-in-recoverymodule-and-other-multisig-creating-contracts)
     - [14. registerAgentsWithSignature operator whitelist bypass](#14-registeragentswithsignature-operator-whitelist-bypass)
     - [15. registerAgentsWithSignature missing msg.value validation](#15-registeragentswithsignature-missing-msgvalue-validation)


### PR DESCRIPTION
The table-of-contents row for entry 12 points at `#12-create-function-1`.

The trailing `-1` is the suffix a renderer appends only when two headings produce the *same* slug, and there is no such collision here: entry 2 is `### 2. \`create\` function` and entry 12 is `### 12. \`create\` function`, which slugify differently because the number is part of the heading text. So the anchor resolves to nothing and the link is dead.

Pre-existing — unrelated to the content added in #318. Found by a table-of-contents integrity check (numbering, duplicates, coverage, ordering, anchor resolution) run across all four vulnerability lists after that PR merged.