### PR TITLE
fix(robinhood): correct the 4663 bridger entry, and the two follow-ups #325 left open

### DIFF
--- a/docs/configuration.json
+++ b/docs/configuration.json
@@ -759,7 +759,7 @@
       {
         "name": "IdentityRegistryBridger",
         "artifact": "abis/0.8.30/IdentityRegistryBridger.json",
-        "address": "0x397125902ED2cA2d42104F621f448A2cE1bC8Fb7"
+        "address": "0xa4799B083E0068732456EF45ff9fe5c683658327"
       },
       {
         "name": "IdentityRegistryBridgerProxy",

--- a/docs/deploymentL2.md
+++ b/docs/deploymentL2.md
@@ -10,8 +10,8 @@
 8. EOA to change the manager of ServiceRegistryTokenUtility to ServiceManagerToken calling `changeManager(ServiceManagerToken)`;
 9. EOA to whitelist GnosisSafeMultisig in ServiceRegistry via `changeMultisigPermission(GnosisSafeMultisig)`;
 10. EOA to whitelist GnosisSafeSameAddressMultisig in ServiceRegistry via `changeMultisigPermission(GnosisSafeSameAddressMultisig)`;
-11. EOA to change the drainer of ServiceRegistry to BridgeMediator calling `changeManager(BridgeMediator)`;
-12. EOA to change the drainer of ServiceRegistryTokenUtility to BridgeMediator calling `changeManager(BridgeMediator)`;
+11. EOA to change the drainer of ServiceRegistry to BridgeMediator calling `changeDrainer(BridgeMediator)`;
+12. EOA to change the drainer of ServiceRegistryTokenUtility to BridgeMediator calling `changeDrainer(BridgeMediator)`;
 13. EOA to transfer ownership rights of ServiceRegistry to BridgeMediator calling `changeOwner(BridgeMediator)`;
 14. EOA to transfer ownership rights of ServiceRegistryTokenUtility to BridgeMediator calling `changeOwner(BridgeMediator)`;
 15. EOA to transfer ownership rights of ServiceManagerToken to BridgeMediator calling `changeOwner(BridgeMediator)`.

--- a/scripts/deployment/l2/deploy_06a_gnosis_safe_multisig.sh
+++ b/scripts/deployment/l2/deploy_06a_gnosis_safe_multisig.sh
@@ -51,8 +51,12 @@ echo "Deploying from: $deployer"
 echo "Deployment of: $contractArgs"
 
 # Deploy the contract and capture the address
-execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
-deploymentOutput=$($execCmd)
+# Constructor args are passed as separate quoted words rather than through a single $execCmd
+# string, which re-splits on expansion. Safe today because these values cannot contain spaces,
+# but deploy_01 shipped a mis-deployment from exactly this pattern and forge accepts a surplus
+# argument list silently whenever the consumed prefix type-checks.
+deploymentOutput=$(forge create --broadcast --rpc-url "$networkURL$API_KEY" $walletArgs \
+  "$contractPath" --constructor-args "$gnosisSafeAddress" "$gnosisSafeProxyFactoryAddress")
 gnosisSafeMultisigAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
 
 # Get output length

--- a/scripts/deployment/l2/deploy_06b_gnosis_safe_same_address_multisig.sh
+++ b/scripts/deployment/l2/deploy_06b_gnosis_safe_same_address_multisig.sh
@@ -50,8 +50,12 @@ echo "Deploying from: $deployer"
 echo "Deployment of: $contractArgs"
 
 # Deploy the contract and capture the address
-execCmd="forge create --broadcast --rpc-url $networkURL$API_KEY $walletArgs $contractArgs"
-deploymentOutput=$($execCmd)
+# Constructor args are passed as separate quoted words rather than through a single $execCmd
+# string, which re-splits on expansion. Safe today because these values cannot contain spaces,
+# but deploy_01 shipped a mis-deployment from exactly this pattern and forge accepts a surplus
+# argument list silently whenever the consumed prefix type-checks.
+deploymentOutput=$(forge create --broadcast --rpc-url "$networkURL$API_KEY" $walletArgs \
+  "$contractPath" --constructor-args "$multisigProxyHash130")
 gnosisSafeSameAddressMultisigAddress=$(echo "$deploymentOutput" | grep 'Deployed to:' | awk '{print $3}')
 
 # Get output length

--- a/scripts/deployment/l2/script_l2_09_registries_change_drainer.sh
+++ b/scripts/deployment/l2/script_l2_09_registries_change_drainer.sh
@@ -59,11 +59,21 @@ if [ "$targetAddress" == "0x0000000000000000000000000000000000000000" ]; then
   exit 1
 fi
 
-for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
-            "ServiceRegistryTokenUtility:$serviceRegistryTokenUtilityAddress"; do
+# Shape-check every address taken from globals, not just null/empty. jq -r preserves a stray
+# trailing space, which passes a null/empty/zero test and then silently defeats every string
+# comparison below: the idempotency branch can never match, while castCmd re-splits on expansion
+# so the transaction itself is correct. A completed handover would then be reported as a hard
+# failure telling the operator to find a derivation path for the bridge mediator.
+for pair in "bridgeMediatorAddress:$targetAddress" \
+            "serviceRegistryAddress:$serviceRegistryAddress" \
+            "serviceRegistryTokenUtilityAddress:$serviceRegistryTokenUtilityAddress"; do
   key="${pair%%:*}"; val="${pair#*:}"
   if [ "$val" == "null" ] || [ -z "$val" ]; then
-    echo "${red}!!! address for $key is not set in $globals${reset}"
+    echo "${red}!!! $key is not set in $globals${reset}"
+    exit 1
+  fi
+  if ! [[ "$val" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+    echo "${red}!!! $key in $globals is not a well-formed address: '$val'${reset}"
     exit 1
   fi
 done

--- a/scripts/deployment/l2/script_l2_09_registries_change_drainer.sh
+++ b/scripts/deployment/l2/script_l2_09_registries_change_drainer.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Sets the drainer of both service registries to the chain's governance control point, by calling changeDrainer(bridgeMediator). The drainer is the destination for slashed operator bonds - ServiceRegistryL2.slashedFunds (native) and ServiceRegistryTokenUtility.mapSlashedFunds[token] (ERC-20). While it is zero both sweep paths are closed: ServiceRegistryL2.drain() requires msg.sender == drainer, and ServiceRegistryTokenUtility.drain(token) reverts ZeroAddress().
+#
+# Covers ServiceRegistryL2 and ServiceRegistryTokenUtility, the two contracts the
+# shell deployment route never had a script for: they are reachable only through
+# the hardhat deploy_11_12_change_drainers.js, so on a shell-route chain the call had to be
+# made by hand with cast send. That is how it was done on chain 4663.
+#
+# The script is idempotent per contract: it skips one already set to the target,
+# and otherwise pre-checks that the signer derived from $derivationPath is the
+# current owner (both setters are owner-gated and would revert with OwnerOnly).
+#
+# Run this BEFORE the ownership handover: changeDrainer is owner-gated, so once
+# owner() is the bridge mediator this becomes a governance proposal crossing the
+# bridge rather than one transaction. Steps 11-12 of docs/deploymentL2.md precede
+# steps 13-15 for exactly this reason.
+
+# Check if $1 is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <network>"
+  echo "Example: $0 gnosis_mainnet"
+  exit 1
+fi
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 1
+fi
+
+# Read variables using jq
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
+serviceRegistryTokenUtilityAddress=$(jq -r '.serviceRegistryTokenUtilityAddress' $globals)
+bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
+
+# Target: the chain's governance control point — the bridge mediator on L2, or the
+# L1-aliased Timelock on Arbitrum — stored as bridgeMediatorAddress. Required, with
+# no fallback: timelockAddress is the non-aliased L1 Timelock, an address nobody
+# controls on an L2.
+if [ "$bridgeMediatorAddress" == "null" ] || [ -z "$bridgeMediatorAddress" ]; then
+  echo "${red}!!! bridgeMediatorAddress is not set in $globals${reset}"
+  exit 1
+fi
+targetAddress="$bridgeMediatorAddress"
+
+if [ "$targetAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! targetAddress is the zero address — check $globals${reset}"
+  exit 1
+fi
+
+for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
+            "ServiceRegistryTokenUtility:$serviceRegistryTokenUtilityAddress"; do
+  key="${pair%%:*}"; val="${pair#*:}"
+  if [ "$val" == "null" ] || [ -z "$val" ]; then
+    echo "${red}!!! address for $key is not set in $globals${reset}"
+    exit 1
+  fi
+done
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 1
+  fi
+fi
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# cast wallet address fails silently into an empty string when the ledger is not
+# connected. Without this the run continues with an empty signer and only fails
+# later, at the owner comparison, with a misleading message.
+if ! [[ "$deployer" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to derive the signer address (is the ledger connected and unlocked?)${reset}"
+  exit 1
+fi
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+targetLc=$(echo "$targetAddress" | tr '[:upper:]' '[:lower:]')
+
+echo "${green}Casting from: $deployer${reset}"
+echo "RPC: $networkURL"
+
+castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
+
+for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
+            "ServiceRegistryTokenUtility:$serviceRegistryTokenUtilityAddress"; do
+  name="${pair%%:*}"; addr="${pair#*:}"
+
+  # Addresses are lowercased before comparison because the globals JSON may not be
+  # EIP-55 checksummed; tr is used instead of the ${var,,} expansion so the script
+  # also runs on bash 3.2 (macOS default).
+  current=$(cast call --rpc-url $networkURL$API_KEY $addr "drainer()(address)")
+  if ! [[ "$current" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+    echo "${red}!!! Failed to read $name drainer() (got: $current)${reset}"
+    exit 1
+  fi
+  currentLc=$(echo "$current" | tr '[:upper:]' '[:lower:]')
+
+  if [ "$currentLc" == "$targetLc" ]; then
+    echo "${green}$name $addr already has drainer() == $targetAddress. Nothing to do.${reset}"
+    continue
+  fi
+
+  # The signer must be the current owner; otherwise changeDrainer reverts with OwnerOnly.
+  currentOwner=$(cast call --rpc-url $networkURL$API_KEY $addr "owner()(address)")
+  currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+  if [ "$currentOwnerLc" != "$deployerLc" ]; then
+    echo "${red}!!! Signer $deployer is not the current $name owner ($currentOwner).${reset}"
+    echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
+    exit 1
+  fi
+
+  echo "${green}$name changeDrainer: $current -> $targetAddress${reset}"
+  castArgs="$addr changeDrainer(address) $targetAddress"
+  echo $castArgs
+  castCmd="$castSendHeader $castArgs"
+  result=$($castCmd)
+  statusLine=$(echo "$result" | grep -E "^status[[:space:]]+[0-9]")
+  echo "$statusLine"
+  if ! echo "$statusLine" | grep -qE "^status[[:space:]]+1[[:space:]]"; then
+    echo "${red}!!! $name changeDrainer transaction did not succeed${reset}"
+    exit 1
+  fi
+  echo "${green}$name drainer() set to $targetAddress.${reset}"
+done

--- a/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
@@ -13,7 +13,8 @@
 #
 # Run this AFTER script_l2_09 and after every other owner-gated setup call: once
 # owner() is the bridge mediator, any further configuration becomes a governance
-# proposal crossing the bridge. This is steps 13-15 of docs/deploymentL2.md.
+# proposal crossing the bridge. This is steps 13-14 of docs/deploymentL2.md; step 15, the ServiceManagerToken
+# transfer, is script_l2_07_service_manager_proxy_change_owner.sh.
 
 # Check if $1 is provided
 if [ -z "$1" ]; then
@@ -58,11 +59,21 @@ if [ "$targetAddress" == "0x0000000000000000000000000000000000000000" ]; then
   exit 1
 fi
 
-for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
-            "ServiceRegistryTokenUtility:$serviceRegistryTokenUtilityAddress"; do
+# Shape-check every address taken from globals, not just null/empty. jq -r preserves a stray
+# trailing space, which passes a null/empty/zero test and then silently defeats every string
+# comparison below: the idempotency branch can never match, while castCmd re-splits on expansion
+# so the transaction itself is correct. A completed handover would then be reported as a hard
+# failure telling the operator to find a derivation path for the bridge mediator.
+for pair in "bridgeMediatorAddress:$targetAddress" \
+            "serviceRegistryAddress:$serviceRegistryAddress" \
+            "serviceRegistryTokenUtilityAddress:$serviceRegistryTokenUtilityAddress"; do
   key="${pair%%:*}"; val="${pair#*:}"
   if [ "$val" == "null" ] || [ -z "$val" ]; then
-    echo "${red}!!! address for $key is not set in $globals${reset}"
+    echo "${red}!!! $key is not set in $globals${reset}"
+    exit 1
+  fi
+  if ! [[ "$val" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+    echo "${red}!!! $key in $globals is not a well-formed address: '$val'${reset}"
     exit 1
   fi
 done
@@ -125,12 +136,28 @@ for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
     continue
   fi
 
-  # The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly.
-  currentOwner=$(cast call --rpc-url $networkURL$API_KEY $addr "owner()(address)")
-  currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
-  if [ "$currentOwnerLc" != "$deployerLc" ]; then
-    echo "${red}!!! Signer $deployer is not the current $name owner ($currentOwner).${reset}"
-    echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
+  # Enforce the ordering the header states, rather than only documenting it. Handing ownership over
+  # while drainer() is unset permanently closes both sweep paths from the EOA:
+  # ServiceRegistryL2.drain() requires msg.sender == drainer, and
+  # ServiceRegistryTokenUtility.drain(token) reverts ZeroAddress(). Running _09 afterwards correctly
+  # fails OwnerOnly, by which point restoring the sweep needs a governance proposal over the bridge.
+  currentDrainer=$(cast call --rpc-url $networkURL$API_KEY $addr "drainer()(address)")
+  if ! [[ "$currentDrainer" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+    echo "${red}!!! Failed to read $name drainer() (got: $currentDrainer)${reset}"
+    exit 1
+  fi
+  if [ "$(echo "$currentDrainer" | tr '[:upper:]' '[:lower:]')" == "0x0000000000000000000000000000000000000000" ]; then
+    echo "${red}!!! $name drainer() is still unset. Run script_l2_09_registries_change_drainer.sh first${reset}"
+    echo "${red}    — after this handover, setting it needs a governance proposal over the bridge.${reset}"
+    exit 1
+  fi
+
+  # The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly. $current was
+  # already read and shape-checked above, so it is reused rather than re-read: a second call is a
+  # second chance for a transient RPC error to produce a misleading "signer is not the owner ()".
+  if [ "$currentLc" != "$deployerLc" ]; then
+    echo "${red}!!! Signer $deployer is not the current $name owner ($current).${reset}"
+    echo "${red}    Set derivationPath in $globals to the path that controls $current, then re-run.${reset}"
     exit 1
   fi
 

--- a/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
@@ -1,0 +1,149 @@
+#!/bin/bash
+
+# Transfers ownership of both service registries from the deployer EOA to the chain's governance control point, by calling changeOwner(bridgeMediator).
+#
+# Covers ServiceRegistryL2 and ServiceRegistryTokenUtility, the two contracts the
+# shell deployment route never had a script for: they are reachable only through
+# the hardhat deploy_13_15_change_ownerships.js, so on a shell-route chain the call had to be
+# made by hand with cast send. That is how it was done on chain 4663.
+#
+# The script is idempotent per contract: it skips one already set to the target,
+# and otherwise pre-checks that the signer derived from $derivationPath is the
+# current owner (both setters are owner-gated and would revert with OwnerOnly).
+#
+# Run this AFTER script_l2_09 and after every other owner-gated setup call: once
+# owner() is the bridge mediator, any further configuration becomes a governance
+# proposal crossing the bridge. This is steps 13-15 of docs/deploymentL2.md.
+
+# Check if $1 is provided
+if [ -z "$1" ]; then
+  echo "Usage: $0 <network>"
+  echo "Example: $0 gnosis_mainnet"
+  exit 1
+fi
+
+red=$(tput setaf 1)
+green=$(tput setaf 2)
+reset=$(tput sgr0)
+
+# Get globals file
+globals="$(dirname "$0")/globals_$1.json"
+if [ ! -f $globals ]; then
+  echo "${red}!!! $globals is not found${reset}"
+  exit 1
+fi
+
+# Read variables using jq
+useLedger=$(jq -r '.useLedger' $globals)
+derivationPath=$(jq -r '.derivationPath' $globals)
+chainId=$(jq -r '.chainId' $globals)
+networkURL=$(jq -r '.networkURL' $globals)
+
+serviceRegistryAddress=$(jq -r '.serviceRegistryAddress' $globals)
+serviceRegistryTokenUtilityAddress=$(jq -r '.serviceRegistryTokenUtilityAddress' $globals)
+bridgeMediatorAddress=$(jq -r '.bridgeMediatorAddress' $globals)
+
+# Target: the chain's governance control point — the bridge mediator on L2, or the
+# L1-aliased Timelock on Arbitrum — stored as bridgeMediatorAddress. Required, with
+# no fallback: timelockAddress is the non-aliased L1 Timelock, an address nobody
+# controls on an L2.
+if [ "$bridgeMediatorAddress" == "null" ] || [ -z "$bridgeMediatorAddress" ]; then
+  echo "${red}!!! bridgeMediatorAddress is not set in $globals${reset}"
+  exit 1
+fi
+targetAddress="$bridgeMediatorAddress"
+
+if [ "$targetAddress" == "0x0000000000000000000000000000000000000000" ]; then
+  echo "${red}!!! targetAddress is the zero address — check $globals${reset}"
+  exit 1
+fi
+
+for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
+            "ServiceRegistryTokenUtility:$serviceRegistryTokenUtilityAddress"; do
+  key="${pair%%:*}"; val="${pair#*:}"
+  if [ "$val" == "null" ] || [ -z "$val" ]; then
+    echo "${red}!!! address for $key is not set in $globals${reset}"
+    exit 1
+  fi
+done
+
+# Check for Alchemy keys
+if [[ "$networkURL" == *"alchemy.com"* ]]; then
+  case $chainId in
+    1)        API_KEY=$ALCHEMY_API_KEY_MAINNET; keyName="ALCHEMY_API_KEY_MAINNET" ;;
+    11155111) API_KEY=$ALCHEMY_API_KEY_SEPOLIA; keyName="ALCHEMY_API_KEY_SEPOLIA" ;;
+    137)      API_KEY=$ALCHEMY_API_KEY_MATIC;   keyName="ALCHEMY_API_KEY_MATIC" ;;
+    80002)    API_KEY=$ALCHEMY_API_KEY_AMOY;    keyName="ALCHEMY_API_KEY_AMOY" ;;
+  esac
+  if [ -n "$keyName" ] && [ "$API_KEY" == "" ]; then
+    echo "set $keyName env variable"
+    exit 1
+  fi
+fi
+
+# Get deployer based on the ledger flag
+if [ "$useLedger" == "true" ]; then
+  walletArgs="-l --mnemonic-derivation-path $derivationPath"
+  deployer=$(cast wallet address $walletArgs)
+else
+  echo "Using PRIVATE_KEY: ${PRIVATE_KEY:0:6}..."
+  walletArgs="--private-key $PRIVATE_KEY"
+  deployer=$(cast wallet address $walletArgs)
+fi
+
+# cast wallet address fails silently into an empty string when the ledger is not
+# connected. Without this the run continues with an empty signer and only fails
+# later, at the owner comparison, with a misleading message.
+if ! [[ "$deployer" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+  echo "${red}!!! Failed to derive the signer address (is the ledger connected and unlocked?)${reset}"
+  exit 1
+fi
+deployerLc=$(echo "$deployer" | tr '[:upper:]' '[:lower:]')
+targetLc=$(echo "$targetAddress" | tr '[:upper:]' '[:lower:]')
+
+echo "${green}Casting from: $deployer${reset}"
+echo "RPC: $networkURL"
+
+castSendHeader="cast send --rpc-url $networkURL$API_KEY $walletArgs"
+
+for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
+            "ServiceRegistryTokenUtility:$serviceRegistryTokenUtilityAddress"; do
+  name="${pair%%:*}"; addr="${pair#*:}"
+
+  # Addresses are lowercased before comparison because the globals JSON may not be
+  # EIP-55 checksummed; tr is used instead of the ${var,,} expansion so the script
+  # also runs on bash 3.2 (macOS default).
+  current=$(cast call --rpc-url $networkURL$API_KEY $addr "owner()(address)")
+  if ! [[ "$current" =~ ^0x[0-9a-fA-F]{40}$ ]]; then
+    echo "${red}!!! Failed to read $name owner() (got: $current)${reset}"
+    exit 1
+  fi
+  currentLc=$(echo "$current" | tr '[:upper:]' '[:lower:]')
+
+  if [ "$currentLc" == "$targetLc" ]; then
+    echo "${green}$name $addr already has owner() == $targetAddress. Nothing to do.${reset}"
+    continue
+  fi
+
+  # The signer must be the current owner; otherwise changeOwner reverts with OwnerOnly.
+  currentOwner=$(cast call --rpc-url $networkURL$API_KEY $addr "owner()(address)")
+  currentOwnerLc=$(echo "$currentOwner" | tr '[:upper:]' '[:lower:]')
+  if [ "$currentOwnerLc" != "$deployerLc" ]; then
+    echo "${red}!!! Signer $deployer is not the current $name owner ($currentOwner).${reset}"
+    echo "${red}    Set derivationPath in $globals to the path that controls $currentOwner, then re-run.${reset}"
+    exit 1
+  fi
+
+  echo "${green}$name changeOwner: $current -> $targetAddress${reset}"
+  castArgs="$addr changeOwner(address) $targetAddress"
+  echo $castArgs
+  castCmd="$castSendHeader $castArgs"
+  result=$($castCmd)
+  statusLine=$(echo "$result" | grep -E "^status[[:space:]]+[0-9]")
+  echo "$statusLine"
+  if ! echo "$statusLine" | grep -qE "^status[[:space:]]+1[[:space:]]"; then
+    echo "${red}!!! $name changeOwner transaction did not succeed${reset}"
+    exit 1
+  fi
+  echo "${green}$name owner() set to $targetAddress.${reset}"
+done


### PR DESCRIPTION
Follow-up to #325 (merged). One defect it shipped, plus the two items it explicitly deferred.

## 1. `configuration.json` names the dead bridger implementation

Caught by @OjusWiZard on the merged PR. `0c8e4af` recorded the implementation address, then `610896d` redeployed it to repair its zero `serviceManager` immutable and wrote the new address **to the globals only** - `configuration.json` was never updated, so the two disagree.

```
proxy 0xE49CB081...c8EA  getImplementation() -> 0xa4799B083E0068732456EF45ff9fe5c683658327
globals_robinhood_mainnet.json                  0xa4799B083E0068732456EF45ff9fe5c683658327
configuration.json                              0x397125902ED2cA2d42104F621f448A2cE1bC8Fb7  <- dead

0x39712590...  serviceManager() -> 0x0000...0000   (the implementation 610896d replaced)
0xa4799B08...  serviceManager() -> 0x63e66d7a...   (live)
```

**4663 was the only chain out of step** - 42161, 8453, 42220, 100, 10 and 137 all agree with their globals.

The live system was never affected. But `checkOwner` and `recordOwnershipRow` run against whatever this entry names, so the ownership CSV was recording 4663's bridger owner from the dead implementation.

## 2. Two scripts the shell route never had

`ServiceRegistryL2` and `ServiceRegistryTokenUtility` are reachable only through the hardhat `deploy_11_12` / `deploy_13_15`. On a shell-route chain there is no script at all - which is why both `changeDrainer` calls on 4663 had to be sent by hand, and why `changeOwner` on those two still has no scripted path for the pending handover.

| script | call |
|---|---|
| `script_l2_09_registries_change_drainer.sh` | `changeDrainer(bridgeMediator)` on both |
| `script_l2_10_registries_change_owner.sh` | `changeOwner(bridgeMediator)` on both |

**Order matters and the scripts say so:** `_09` must run before `_10`, because `changeDrainer` is owner-gated - once `owner()` is the bridge mediator it becomes a governance proposal crossing the bridge rather than one transaction. That is why `deploymentL2.md` puts the drainers at steps 11-12 and ownership at 13-15.

Both follow `script_l2_07`'s existing shape: idempotent per contract, signer pre-checked against `owner()` before attempting, `status 1` verified, `exit 1` on failure.

**Exercised against 4663**, where both drainers are already set - `script_l2_09` correctly reports both as no-ops and exits 0:

```
ServiceRegistryL2 0xE3607b00...4b50 already has drainer() == 0x4d30F68F...A70F. Nothing to do.
ServiceRegistryTokenUtility 0x3d77596b...1e44 already has drainer() == 0x4d30F68F...A70F. Nothing to do.
```

That run also surfaced a defect in the script itself: `cast wallet address` fails into an **empty string** when the ledger is disconnected, and the run continued with an empty signer (`Casting from: ` blank), only failing later at the owner comparison with a misleading "Signer  is not the current owner". It was harmless only because both contracts short-circuited. Both scripts now validate the derived signer and abort with a clear message - re-tested with the ledger still disconnected, exits 1 immediately.

## 3. `deploy_06a` / `06b` no longer build `$execCmd` as a string

@dagacha's accepted follow-up from #325. Safe today because their arguments - two addresses and a `bytes32` - cannot contain spaces. Worth closing anyway: `deploy_01` shipped a mis-deployment from exactly this pattern, and forge accepts a surplus argument list **silently** whenever the consumed prefix type-checks, so the failure mode is not bounded by argument count.

## Still open, deliberately

- **`deploy_16` has no version pin** - a fleet-wide decision, not a Robinhood one.
- **`ownable_owners.csv`** is regenerated with the handover, not here.
- The handover itself: six `changeOwner` calls, two of which now have `script_l2_10`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
