### PR TITLE
fix: require the intended drainer before handing over ownership

### DIFF
--- a/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
@@ -146,9 +146,18 @@ for pair in "ServiceRegistryL2:$serviceRegistryAddress" \
     echo "${red}!!! Failed to read $name drainer() (got: $currentDrainer)${reset}"
     exit 1
   fi
-  if [ "$(echo "$currentDrainer" | tr '[:upper:]' '[:lower:]')" == "0x0000000000000000000000000000000000000000" ]; then
-    echo "${red}!!! $name drainer() is still unset. Run script_l2_09_registries_change_drainer.sh first${reset}"
-    echo "${red}    — after this handover, setting it needs a governance proposal over the bridge.${reset}"
+  # Require the intended drainer, not merely a non-zero one. A stale or mistyped value would otherwise
+  # survive the handover, leaving native draining authority (ServiceRegistryL2) or the ERC-20 proceeds
+  # destination (ServiceRegistryTokenUtility) with that address, correctable only by governance.
+  currentDrainerLc=$(echo "$currentDrainer" | tr '[:upper:]' '[:lower:]')
+  if [ "$currentDrainerLc" != "$targetLc" ]; then
+    if [ "$currentDrainerLc" == "0x0000000000000000000000000000000000000000" ]; then
+      echo "${red}!!! $name drainer() is still unset.${reset}"
+    else
+      echo "${red}!!! $name drainer() is $currentDrainer, not the intended $targetAddress.${reset}"
+    fi
+    echo "${red}    Run script_l2_09_registries_change_drainer.sh first — after this handover,${reset}"
+    echo "${red}    changing it needs a governance proposal over the bridge.${reset}"
     exit 1
   fi
 


### PR DESCRIPTION
The drainer guard added in #326 only rejected the **zero** address. A stale or mistyped non-zero drainer survived the handover, leaving native draining authority (`ServiceRegistryL2`) or the ERC-20 proceeds destination (`ServiceRegistryTokenUtility`) assigned to that address — correctable only by governance, since `changeDrainer` is owner-gated.

@dagacha reproduced it: with `drainer()` set to the deployer, the script sent both ownership transactions and exited 0.

It now compares the normalised drainer against the intended target and aborts on any mismatch, distinguishing "still unset" from "set to something else" so the message tells the operator which case they're in.

Fixtures:

```
intended mediator                exit=0
unset                            exit=1  drainer() is still unset.
deployer (the reported case)     exit=1  drainer() is 0xEB2A22b2..., not the intended 0x4d30F68F...
unreadable                       exit=1  Failed to read drainer()
```

4663 is already past this point — both drainers are the mediator — so this protects the next shell-route chain.
