### PR TITLE
docs(l2): script_l2_10 header claimed an ownership transfer that has not happened

### DIFF
--- a/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
+++ b/scripts/deployment/l2/script_l2_10_registries_change_owner.sh
@@ -5,7 +5,7 @@
 # Covers ServiceRegistryL2 and ServiceRegistryTokenUtility, the two contracts the
 # shell deployment route never had a script for: they are reachable only through
 # the hardhat deploy_13_15_change_ownerships.js, so on a shell-route chain the call had to be
-# made by hand with cast send. That is how it was done on chain 4663.
+# made by hand with cast send. This script exists so that no longer has to be true.
 #
 # The script is idempotent per contract: it skips one already set to the target,
 # and otherwise pre-checks that the signer derived from $derivationPath is the


### PR DESCRIPTION
The `script_l2_10_registries_change_owner.sh` header says the by-hand `cast send` route "is how it was done on chain 4663".

That is true of the **drainer** calls. It is not true of ownership: on 4663 both `ServiceRegistryL2` and `ServiceRegistryTokenUtility` still read `owner() == 0xEB2A22b27C7Ad5eeE424Fd90b376c745E60f914E`, the deployer EOA, and this handover has not run on any chain through this script yet.

The sentence sits directly above the ordering instructions an operator reads while performing the handover, where "already done on 4663" is exactly the wrong thing to believe. Replaced with what the script is actually for.

My wording, from the commit that added the script. Found while auditing the 4663 ownership handover.
