### PR TITLE
feat: record the HashCheckpoint addresses in the three globals files

### DIFF
--- a/scripts/deployment/l2/globals_arbitrum_mainnet.json
+++ b/scripts/deployment/l2/globals_arbitrum_mainnet.json
@@ -40,5 +40,6 @@
   "agent8004BaseURI": "https://marketplace.olas.network/erc8004/arbitrum-one/ai-agents/",
   "identityRegistryBridgerAddress": "0x379451B13e4900C7005Bf57467770b2EE4e62a86",
   "identityRegistryBridgerProxyAddress": "0x22bE6fDcd3e29851B29b512F714C328A00A96B83",
-  "complementaryServiceMetadataAddress": "0x02C26437B292D86c5F4F21bbCcE0771948274f84"
+  "complementaryServiceMetadataAddress": "0x02C26437B292D86c5F4F21bbCcE0771948274f84",
+  "hashCheckpointAddress": "0x343F2B005cF6D70bA610CD9F1F1927049414B582"
 }

--- a/scripts/deployment/l2/globals_celo_mainnet.json
+++ b/scripts/deployment/l2/globals_celo_mainnet.json
@@ -46,5 +46,6 @@
   "newStakingTokenAddress": "0xd2ff4Cf0927c3cFbF3BB27391044dBaf6f4ca7b9",
   "identityRegistryBridgerAddress": "0x88943F63E29cd436B62cFfE332aD54De92AdCE98",
   "identityRegistryBridgerProxyAddress": "0x7fc0ddf4DFB61CfA5519db2A5eE7B2Eb02De0140",
-  "complementaryServiceMetadataAddress": "0xc096362fa6f4A4B1a9ea68b1043416f3381ce300"
+  "complementaryServiceMetadataAddress": "0xc096362fa6f4A4B1a9ea68b1043416f3381ce300",
+  "hashCheckpointAddress": "0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4"
 }

--- a/scripts/deployment/l2/globals_robinhood_mainnet.json
+++ b/scripts/deployment/l2/globals_robinhood_mainnet.json
@@ -40,5 +40,6 @@
   "stakingTokenAddress": "0x87c511c8aE3fAF0063b3F3CF9C6ab96c4AA5C60c",
   "stakingNativeTokenAddress": "",
   "stakingVerifierAddress": "0x75D529FAe220bC8db714F0202193726b46881B76",
-  "stakingFactoryAddress": "0x1BD1505B711Fb58C54ca3712e6BEf47A133892d9"
+  "stakingFactoryAddress": "0x1BD1505B711Fb58C54ca3712e6BEf47A133892d9",
+  "hashCheckpointAddress": "0x92499E80f50f06C4078794C179986907e7822Ea1"
 }


### PR DESCRIPTION
Follow-up to #331, which landed the `docs/configuration.json` entries and the artifact but not these.

`deploy_23_hash_checkpoint_l2.sh` writes `hashCheckpointAddress` back into the globals file it was run against — that is how every other deployed address in these files got there. I ran the three deployments from the main checkout rather than from the branch worktree, so the write-backs landed outside the PR and were very nearly discarded as an untracked dirty working tree during cleanup.

| file | address |
|---|---|
| `globals_arbitrum_mainnet.json` | `0x343F2B005cF6D70bA610CD9F1F1927049414B582` |
| `globals_celo_mainnet.json` | `0x408dCA2b565f5eC7779C181870feFb51Ed67C3F4` |
| `globals_robinhood_mainnet.json` | `0x92499E80f50f06C4078794C179986907e7822Ea1` |

Same three addresses as the `configuration.json` entries merged in #331, and all three are `exact_match` on Sourcify with ownership already transferred to each chain's bridge mediator.
